### PR TITLE
Adding translated annotations from Nestor's Haydn Op20

### DIFF
--- a/Corpus/HaydnOp20/op20n1-01.txt
+++ b/Corpus/HaydnOp20/op20n1-01.txt
@@ -1,0 +1,93 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in E-flat Major - No.1: Allegro moderato
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 Eb: I
+m4 b2 V7 b3 I
+m6 b4 V43/V
+m7 b1 V6
+m8 b1 V6
+m9 b1 V65/V
+m10 b3 V7
+m11 b1 I b3 I6
+m12 b1 I
+m13 b1 V6 b3 I
+m14 b1 V6 b3 vi b4 V7/V
+m15 b1 V
+m16 b1 I6 b3 V2/ii
+m17 b3 ii6
+m19 b3 viio43 b4.5 I6
+m20 b1 I6
+m21 b1 viio65/vi b2 vi b3 V64 b4.5 V6
+m22 b1 I b3 V64 b4 V/V
+m24 b3 V6
+m26 b1 V65 b3 I
+m27 b3 viio7/V/V
+m28 b1 V
+m29 b3 I b4 vi
+m31 b1 V65/V b2 V b3 vi6 b4 V64 b4.5 V7/V
+m32 b1 V
+m33 b1 V
+m34 b1 V
+m35 b1 V/V
+m36 b1 V b4 V b4.5 I64
+m37 b1 V b4.5 I64
+m38 b1 V
+m41 b1 V/vi b2 III
+m44 b1 I
+m47 b3 ii
+m48 b3 V
+m50 b1 V6/ii
+m51 b3 V65/ii
+m52 b3 ii
+m53 b3 V6
+m54 b3 I
+m55 b3 V65/vi
+m56 b3 vi
+m57 b3 viio43/vi
+m58 b1 vi b3 viio43/vi
+m59 b1 vi b3 N6/vi
+m60 b3 viio7/V/vi
+m61 b1 vi
+m62 b3 iio6/vi b4 V/vi
+m63 b1 vi
+m64 b3 ii
+m65 b4 V7/V
+m66 b1 v
+m67 b1 V7/IV b3 IV64
+m68 b1 IV
+m71 b3 V2
+m73 b1 I
+m77 b3 I6
+m78 b1 I
+m79 b1 V b3 I
+m80 b1 V6 b3 vi7 b4 ii
+m81 b1 V7 b2 I7 b3 IV7 b4 viio
+m82 b1 iii7 b2 vi7 b3 V/V
+m83 b1 V
+m85 b3 I6
+m86 b1 V2/ii
+m87 b1 ii6
+m88 b1 V2
+m89 b1 I6
+m90 b3 IV
+m91 b3 viio65/ii b4 ii6
+m92 b1 I64 b3 ii65
+m93 b1 I64 b3 V7
+m94 b1 I64 b3 V7
+m95 b1 I b2 V65/IV b3 IV
+m96 b4.5 V7
+m97 b1 I
+m98 b2 V7/IV b3 IV6 b4 ii
+m100 b1 V65 b2 I b3 ii6 b4 I64 b4.5 V
+m101 b1 I
+m102 b1 V
+m103 b1 I b3 V6 b4 ii43
+m104 b1 V b2 ii65 b3 I6 b4.5 V
+m105 b1 I b4 IV64 b4.5 viio
+m106 b1 I b4 IV64 b4.5 viio
+m107 b1 I
+m108 b1 viio7/V/V b3 V7/V b4 V6/iii
+m109 b1 viio6 b3 I

--- a/Corpus/HaydnOp20/op20n1-02.txt
+++ b/Corpus/HaydnOp20/op20n1-02.txt
@@ -1,0 +1,69 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in E-flat Major - No.2: Menuetto: un poco allegretto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m1 b1 Eb: I
+m2 b1 V43
+m3 b1 I
+m4 b1 V65
+m5 b1 I
+m6 b1 IV
+m7 b1 IV b3 V
+m8 b1 I
+m9 b1 V6 b3 It
+m10 b1 V b3 I
+m11 b1 V6 b3 It
+m12 b1 V b3 v
+m13 b1 v
+m14 b1 V7/v
+m15 b1 v b3 viio7/V/v
+m16 b1 V/v b3 Bb: I6
+m17 b1 I6
+m18 b1 ii6
+m19 b1 I64 b3 None
+m20 b1 I
+m21 b1 V43/IV
+m22 b1 I
+m23 b1 V43/IV
+m24 b1 I
+m25 b1 Eb: I
+m26 b1 V43
+m27 b1 I
+m28 b1 V65
+m29 b1 I
+m30 b1 IV
+m31 b1 IV
+m32 b1 I
+m33 b1 I
+m34 b1 V43
+m35 b1 I
+m36 b1 viio65/V
+m38 b1 V7
+m39 b1 I64 b3 V7
+m40 b1 I b3 V65
+m41 b1 viio
+m42 b1 I
+m43 b1 ii6 b3 V7
+m44 b1 I
+m45 b1 IV
+m46 b1 None b3 viio6/IV
+m47 b1 None b2 IV6 b3 viio/IV/IV
+m48 b1 IV/IV
+m49 b1 I
+m50 b1 IV6/IV
+m51 b1 ii
+m52 b1 I
+m53 b1 V
+m54 b1 I
+m55 b1 viio6/IV
+m56 b1 IV6
+m57 b1 viio43/V
+m58 b1 V6
+m59 b1 viio43/V/ii
+m60 b1 V6/ii
+m62 b1 ii
+m63 b1 V64/ii
+m64 b1 ii
+m65 b1 V65/ii

--- a/Corpus/HaydnOp20/op20n1-03.txt
+++ b/Corpus/HaydnOp20/op20n1-03.txt
@@ -1,0 +1,98 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in E-flat Major - No.3: Affettuoso e sostenuto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/8
+m1 b1 Ab: I
+m2 b1 IV64
+m4 b1 I6 b2 V65 b3 I
+m5 b1 ii6 b2 I64 b3 V7
+m6 b1 I
+m8 b1 I
+m9 b1 IV b3 V43
+m10 b1 I b2 IV6
+m11 b1 I6 b2 V65 b3 I
+m12 b1 ii6 b3 viio/V
+m13 b1 V
+m14 b1 V65 b2 I64 b3 viio6/vi
+m15 b1 vi b2 V b3 V65/V
+m16 b1 V b2 vi b3 V6
+m17 b1 vi6 b3 viio7/V/V
+m18 b1 V/V b2 viio/V/V b3 V6/V
+m19 b1 iii7
+m20 b1 viio7/V b2 V b3 V2
+m21 b1 I7 b2 viio/V/V b3 I6
+m22 b1 V7 b2 viio7/iii b3 iii
+m23 b1 vi b3 V7
+m24 b1 V6
+m25 b1 V/vi b2 vi b3 vi2
+m26 b1 V65/V b2 v b3 ii6
+m27 b1 Ger7/V
+m28 b1 V64 b2 V/V
+m29 b1 iii2
+m30 b1 V2/V
+m32 b1 V b2 V65
+m33 b1 I6 b2 V64 b3 V/V
+m34 b1 V
+m35 b1 V b3 V7/V
+m36 b1 V b2 I64
+m37 b1 V b3 V7/V
+m38 b1 V
+m39 b1 Eb: I
+m40 b1 IV64 b3 V7
+m41 b1 I b2 IV
+m42 b1 I6 b2 V65 b3 I
+m43 b1 ii6 b2 I64 b3 V7
+m44 b1 I
+m45 b1 vi b2 v b3 viio7/v
+m46 b1 bb: vi b2 ii b3 i6
+m47 b1 iio65 b3 V65
+m48 b1 VI
+m49 b1 V6/III b3 V65/III
+m50 b1 Db: I b2 ii b3 I6
+m51 b1 ii6 b2 I64 b3 V7
+m52 b1 I
+m53 b1 IV b3 Ger7/V
+m54 b1 V/V
+m55 b1 V b3 Ger7/vi
+m56 b1 V/vi
+m57 b1 bb: i
+m58 b1 iio65 b3 iio7/iv
+m59 b1 V65/iv b3 iio2/III
+m60 b1 V65/III
+m61 b1 III b3 V/III
+m62 b1 III
+m63 b1 iv b2 v b3 VI
+m64 b1 V/III b3 V7/IV
+m65 b1 IV b3 viio/IV
+m66 b1 IV b3 viio/IV
+m67 b1 IV b3 i
+m68 b1 V/III
+m69 b1 III b3 vi
+m70 b1 III64 b3 III
+m71 b1 V6/III
+m72 b1 i b2 V64/III b3 iv7
+m73 b1 V2 b3 None
+m74 b1 V2/V/III
+m75 b1 III b3 viio7/IV
+m76 b1 V/VII b2 viio6/V/VII b3 V6/V/VII
+m77 b1 Ab: vi65
+m78 b1 V65 b2 I b3 I2
+m79 b1 vi7 b2 viio7 b3 ii43
+m80 b1 V7 b2 viio7/vi b3 vi
+m81 b1 IV b2 I64 b3 V7
+m82 b1 I6
+m83 b1 V7/ii b2 ii b3 ii2
+m84 b1 viio b2 i b3 V64
+m85 b1 Ger7
+m86 b1 V7
+m87 b1 vi7
+m88 b1 V2
+m90 b1 I b2 V65/IV
+m91 b1 None b1.5 IV b2 I64 b3 V7
+m92 b1 I
+m93 b3 V7
+m94 b1 I b2 IV64 b3 I
+m95 b3 V7
+m96 b1 I

--- a/Corpus/HaydnOp20/op20n1-04.txt
+++ b/Corpus/HaydnOp20/op20n1-04.txt
@@ -1,0 +1,148 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in E-flat Major - No.4: Finale: Presto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 2/4
+m0 b2.5 Eb: I
+m2 b1 V65/V
+m3 b1 I
+m5 b1 IV
+m6 b1 I
+m8 b1 V6 b2.5 V65
+m9 b1 I
+m11 b1 V6
+m12 b1 vi b2 IV6
+m13 b1 iii6
+m14 b1 IV b2 ii6
+m15 b1 I6
+m16 b1 viio6
+m17 b1 ii6
+m18 b1 V
+m19 b1 viio6/V
+m20 b1 V
+m21 b1 viio65/ii
+m22 b1 viio65/ii
+m23 b1 viio65/ii
+m24 b1 viio65/ii
+m25 b1 V65/ii
+m26 b1 V65/ii
+m27 b1 V7/V
+m28 b1 V64
+m29 b1 V7/V
+m30 b1 V/V
+m31 b1 viio/V/V
+m32 b1 V/V
+m33 b2.5 Bb: I
+m35 b2.5 I
+m38 b1 V65/V
+m39 b1 V43/V
+m40 b1 V65/V
+m41 b1 V43/V
+m42 b1 I64 b2.75 V
+m43 b1 I64 b2.75 V
+m44 b1 I64
+m46 b1 I64
+m47 b1 V7
+m48 b1 I b2.5 I
+m49 b1 IV64 b2.5 V7
+m50 b1 I b2.5 I
+m51 b1 IV64 b2.5 viio
+m52 b1 I b2.5 I
+m53 b1 IV64 b2.5 V7
+m54 b1 I
+m57 b1 V65
+m58 b1 IV
+m59 b1 i
+m60 b1 f: V7
+m61 b1 i64
+m62 b1 V7
+m63 b1 i64
+m64 b1 viio7/V
+m65 b1 V b2 V
+m66 b2 i
+m67 b1 V7/iv
+m68 b1 iv b2 iv
+m69 b2 III/V
+m70 b1 c: V7/VI
+m71 b1 VI
+m72 b1 ii b2.5 viio6/V
+m73 b1 V
+m74 b1 i64
+m75 b1 V
+m76 b1 V7
+m77 b1 V
+m78 b1 V
+m79 b1 V
+m80 b1 viio43
+m81 b1 i6
+m82 b1 N6
+m83 b1 viio65/iv
+m84 b1 iv6
+m85 b1 viio65/v
+m86 b1 v6
+m87 b1 viio65/v
+m88 b1 V65/v
+m89 b1 v
+m90 b1 Ger7/V
+m91 b1 Ger7/V
+m92 b1 V7/VI
+m93 b1 V7/VI
+m94 b1 VI64
+m95 b1 III
+m96 b1 III
+m97 b1 viio65/V/III
+m98 b1 viio65/V/III
+m99 b1 viio65/V/III
+m100 b1 viio65/V/III
+m101 b1 V/III
+m102 b1 III64
+m103 b1 V/III
+m104 b1 III64
+m105 b1 V/III
+m108 b1 Eb: V65/V
+m109 b1 I
+m111 b1 IV
+m112 b1 I
+m114 b1 V6 b2.5 V65
+m115 b1 I
+m117 b1 V6
+m118 b1 vi b2 IV6
+m119 b1 iii6
+m120 b1 IV b2 ii6
+m121 b1 I6
+m122 b1 viio6
+m123 b1 ii6
+m124 b1 V b2.5 V7
+m125 b1 I
+m126 b1 viio65/V
+m127 b1 viio65/V
+m128 b1 viio65/V
+m129 b1 viio65/V
+m130 b1 V6/V
+m131 b1 V7/V
+m132 b1 V7
+m133 b1 I64
+m134 b1 V7
+m135 b1 V
+m136 b1 vi
+m137 b1 viio/V b1.5 V
+m138 b2.5 I
+m140 b2.5 I
+m142 b2.5 I
+m143 b1 V65/V
+m144 b1 V43/V
+m145 b1 V43/V
+m146 b1 V43/V
+m147 b1 I64 b2.75 V
+m148 b1 I64 b2.75 V
+m149 b1 I64
+m152 b1 V7
+m153 b1 I
+m154 b1 IV64 b2 I
+m155 b1 I
+m156 b1 IV64 b2 I
+m157 b1 I
+m158 b1 IV
+m159 b1 viio
+m160 b1 I

--- a/Corpus/HaydnOp20/op20n2-01.txt
+++ b/Corpus/HaydnOp20/op20n2-01.txt
@@ -1,0 +1,104 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in C Major - No.1: Moderato
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 C: I
+m2 b1 I6
+m4 b1 I
+m5 b1 V7/IV
+m6 b1 I
+m7 b1 V
+m8 b1 V
+m10 b1 V b3 ii2/V
+m11 b1 V7 b3 I64
+m12 b1 V
+m14 b1 V
+m15 b1 I b3 V65
+m16 b1 V7/IV b3 IV64 b4 ii2
+m17 b1 V7/IV b3 IV64 b4 ii2
+m18 b1 I
+m19 b1 V7 b3 IV
+m20 b1 viio43/ii b1.5 ii6 b3 I64
+m21 b1 V
+m22 b1 ii/V b3 V7/V
+m23 b1 V
+m24 b1 vi/V b3 iii6/V
+m25 b1 ii6/V
+m26 b1 V7/V
+m27 b1 V7/V b3 V
+m28 b1 viio7/V/V b2 V6/V b3 V7
+m29 b1 I b2.5 V7/V b3 V
+m30 b1 I b2 viio/V b3 iii/V b4 vi/V
+m31 b1 ii/V b2 V7/V b3 V b4 V6/V b4.5 V
+m32 b1 V/V b2.5 V b3 V/V b4.5 V
+m33 b1 V/V b3 G: IV b4.5 V7
+m34 b1 vi b2.5 ii6 b3 iii b4.5 IV
+m35 b1 V b2.5 I6 b3 ii b4.5 V6
+m36 b1 vi b4 V6
+m37 b1 V65
+m39 b1 i
+m40 b1 VI/i
+m42 b1 Ger7/i
+m43 b1 I64 b4.5 V7
+m44 b1 I b2.5 viio b3 I
+m45 b4.5 V7
+m46 b1 I b2.5 viio b3 I b4.5 viio
+m47 b1 I b2.5 V7 b3 I
+m48 b1 i
+m49 b1 V65/v
+m50 b1 v
+m51 b1 V65
+m52 b1 V7/vi
+m53 b1 vi
+m54 b1 IV
+m55 b1 V65/vii
+m56 b1 V7/V
+m57 b1 v6
+m58 b1 III/i
+m59 b1 viio7/V/v
+m60 b1 V/v
+m61 b1 i
+m62 b1 i6 b4 V65/III
+m63 b1 III b3 V2/V
+m64 b1 v
+m65 b1 V2 b3 V7/VI
+m68 b1 viio65/V/v
+m69 b1 v64
+m70 b1 viio7/V/v
+m71 b1 V/v
+m72 b1 a: iv b2.5 V7 b3 VI b4.5 ii6
+m73 b1 i6 b3 viio43
+m74 b1 i6 b3 N6 b4.5 V7
+m75 b1 VI b3 III
+m76 b1 i b2.5 V7 b3 i
+m77 b2.5 viio b4 i
+m78 b2 viio65/iv b3 iv6
+m79 b1 iv b1.5 V65/iv b2 iv b2.5 viio43/VII b3 VII6 b3.5 V7/III b4 vi/III b4.5 IV/III
+m80 b1 III64 b3 V7/III
+m81 b1 C: I
+m82 b1 I
+m84 b1 I b2 V65/IV b3 IV b4.5 V/V
+m85 b1 V b3 V7
+m86 b3 I
+m87 b1 viio43/V b2 V6 b3 V7
+m88 b1 IV b2.5 V7 b3 I
+m89 b1 IV b2 viio b3 iii b4 vi
+m90 b1 ii b2 V6 b3 I b4 V7 b4.5 I64
+m91 b1 V b2 V7 b2.5 I64 b3 V b4 V7 b4.5 I64
+m92 b1 V b4.5 V7
+m93 b1 vi b2.5 ii65 b3 iii b4.5 IV
+m94 b1 V b2.5 I64 b4 viio7
+m95 b1 I b3 viio43/V b4 V6
+m96 b1 viio7
+m97 b1 V65
+m98 b1 i
+m99 b1 VI/i
+m100 b1 VI/i
+m101 b1 Ger7/i
+m102 b1 e: I64 b4.5 V7
+m103 b1 I b2.5 viio b3 I
+m104 b4.5 V7
+m105 b1 I b2.5 viio b3 I b4.5 viio
+m106 b1 I b2.5 V7 b3 I

--- a/Corpus/HaydnOp20/op20n2-02.txt
+++ b/Corpus/HaydnOp20/op20n2-02.txt
@@ -1,0 +1,64 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in C Major - No.2: Adagio
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 c: i b3 V6
+m2 b1 i b2 iv6 b3 VII
+m3 b1 III6 b2 VI b3 ii6 b4 V7
+m4 b1 i6 b2 iv6 b3 V
+m5 b1 i b3 V65
+m6 b1 i b2 iv65 b3 VII
+m7 b1 III7 b2 VI b3 iio65 b4 V
+m8 b1 i b1.5 V2/iv b2 iv6 b3 iv6 b3.5 V65/iv b4 iv
+m10 b3 III6 b3.5 V43/III b4 III
+m11 b1 III b1.5 V2/VI b2 VI6
+m14 b1 viio7/iv/iv
+m17 b3.38 iv/iv
+m18 b1 iv/iv b3.38 V65/iv
+m19 b1.5 iv b3 viio6/iv b3.5 iv6/iv
+m20 b1 iv6
+m21 b1 viio7
+m22 b1 i
+m23 b1 viio7/v
+m24 b1 V2/v b1.5 v6 b2 viio6/v b2.5 v b3 viio7/v
+m25 b3.38 V65/V
+m26 b1 g: i b3 V65
+m27 b1 i b2 iv65 b3 VII
+m28 b1 III7 b2 VI b3 iio65 b4 V7
+m29 b1 i6 b1.5 V65 b2 i b3 i b3.5 V2/iv b4 iv6 b4.5 V65/iv
+m30 b1 c: i b2 VI b4 i64
+m31 b1 i64 b2 viio7/V
+m32 b4 viio7/V
+m33 b1 V
+m34 b1 Eb: I
+m35 b1 V7 b3 I
+m36 b1 IV b3 I
+m37 b1 V7 b3 I
+m38 b1 I b3 V6
+m39 b1 vi7 b2 V7/V b3 V
+m40 b1 V6 b3 I
+m41 b1 vi65 b2 V65/V/V b3 V7/V
+m42 b1 Bb: I7 b2 V7 b3 I7 b4 V7
+m43 b1 I7 b2 V7 b3 I7 b4 V7
+m44 b1 I65 b3 IV
+m45 b1 I43 b2 V7 b3 I7 b4 V7
+m46 b1 I6 b3 I+6
+m47 b1 IV b3 IV6 b3.5 ii b4 IV6 b4.5 I6
+m48 b1 IV6 b1.5 IV b2 IV b2.5 ii b3 IV b3.5 ii b4 IV b4.5 ii
+m49 b1 V7
+m50 b3 I
+m51 b1 f: VI b4 V65
+m52 b3 i
+m53 b1 i b3 V7
+m54 b1 i
+m55 b1 V7/VII b3 VII
+m56 b1 VII b3 V/VII
+m57 b1 VII
+m58 b1 V2/III b3 V7
+m59 b2 i6
+m60 b1 viio65/V/v b3 V/v b4 V/v b4.5 v
+m61 b1 V/v b1.5 v b2 V/V b2.5 v b3 V/V b3.5 v b4 V/V b4.5 v
+m62 b1 V/v b1.5 V/v b2 V7/v b2.5 v b3 V/v b3.5 V/v b4 V7/v b4.5 v
+m63 b1 V/v

--- a/Corpus/HaydnOp20/op20n2-03.txt
+++ b/Corpus/HaydnOp20/op20n2-03.txt
@@ -1,0 +1,72 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in C Major - No.3: Menuetto: Allegretto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m1 b1 C: I
+m2 b1 I
+m3 b1 V7
+m4 b1 I
+m5 b1 I
+m6 b1 V7
+m8 b1 IV
+m10 b1 V/iii
+m11 b1 I b3 viio6/V
+m12 b1 V6 b3 V6/V
+m13 b1 V
+m19 b1 V7/V
+m20 b1 V
+m21 b1 c: V
+m22 b1 V7 b2 I b3 viio43/V
+m23 b1 V
+m24 b1 V7 b2 I b3 viio43/V
+m25 b1 V
+m26 b1 V7 b2 I b3 viio43/V
+m27 b1 V b3 viio43/V
+m28 b1 V
+m29 b1 C: I
+m30 b1 I
+m31 b1 V
+m32 b1 I
+m33 b1 I
+m34 b1 V7
+m36 b1 IV
+m38 b1 I6
+m39 b1 V/IV
+m40 b1 IV b3 viio
+m41 b1 I6 b3 V65
+m42 b1 I
+m46 b3 vi
+m47 b1 ii6 b3 V
+m48 b1 I
+m49 b1 I
+m50 b1 I
+m51 b1 V7
+m52 b1 I
+m53 b1 I b2 V6 b3 I
+m54 b1 IV
+m55 b1 V7
+m56 b1 I
+m57 b1 i
+m58 b1 iv65
+m59 b1 VII
+m60 b1 III65
+m61 b1 VI
+m62 b1 iio65
+m63 b1 V7
+m64 b1 i6
+m65 b1 iv6 b2 V b3 viio/V
+m66 b1 V
+m67 b1 i b3 viio/V
+m68 b1 V
+m69 b1 iv/iv
+m70 b1 VI/iv
+m71 b1 V7/iv
+m72 b1 iv6 b2 viio/iv b3 iv
+m73 b1 iv/V
+m74 b1 vi/V
+m75 b1 V/V
+m76 b1 V6 b2 vii/V b3 V
+m77 b1 V
+m84 b1 V

--- a/Corpus/HaydnOp20/op20n2-04.txt
+++ b/Corpus/HaydnOp20/op20n2-04.txt
@@ -1,0 +1,167 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in C Major - No.4: Fuga a quattro soggeti: Allegro
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 6/8
+m1 b1 C: None
+m2 b1 I b2 ii6
+m3 b1 I64 b2 ii
+m4 b1 V65 b2 I
+m5 b1 I
+m6 b1 vi6 b2.67 V
+m7 b1 I6 b2 V7/V
+m8 b1 V
+m9 b1 I6 b2 ii65
+m10 b1 V b1.67 I64 b2 ii65
+m11 b1 V7
+m12 b1 I b1.67 V2/IV b2 IV6
+m13 b1 vi64 b2.67 V
+m14 b1 I b2 V2/V
+m15 b1 V6 b2.67 viio
+m16 b1 I b2 ii65
+m17 b1 V2 b1.67 I6 b2 IV2
+m18 b1 V65 b2 I
+m19 b1 ii65 b1.33 V b2.33 IV
+m20 b1 viio65 b1.33 iii b2.33 ii
+m21 b1 V65 b1.33 I b1.67 iii b2 ii6
+m22 b1 I6 b2 viio6
+m23 b1 vi6 b1.67 V7/vi
+m24 b1 viio6
+m25 b1 viio6
+m26 b1 I6
+m27 b1 IV2
+m28 b1 ii7
+m29 b1 vi b1.67 IV+64 b2 ii
+m30 b1 V b1.67 I64 b2 vii b2.33 V2
+m31 b1 I6 b2 V/V b2.67 V7
+m32 b1 I b2.33 viio b2.67 viio64/IV
+m33 b1 IV6
+m34 b1 IV b2.67 viio/IV/IV
+m35 b1 IV/IV b1.67 It/i b2 V b2.67 viio
+m36 b1 I b1.67 It/ii b2 V/ii b2.67 V7/ii
+m37 b1 VI/ii b1.67 It/i
+m38 b1 I
+m39 b1 ii
+m40 b1 IV/IV
+m41 b1 v7 b1.67 ii6 b2 V7/ii b2.67 V7/ii
+m42 b1 d: i b2 V b2.33 viio/V b2.67 V65
+m43 b1 i b1.67 III
+m44 b1 V65 b1.67 i b2 viio2 b2.67 iv6
+m45 b1 V7 b2 ii
+m46 b1 V/iv b2 iv6
+m47 b1 i6 b1.67 iv6 b2.67 v7
+m48 b1 VI6 b1.67 iv7 b2.67 III64
+m49 b1 V/III b1.67 V7/III
+m50 b1 III
+m51 b1 VI
+m52 b1 iv6/iv
+m53 b1 VII
+m54 b1 III+6
+m55 b1 i
+m56 b1 V
+m57 b1 V6/IV b2.33 viio64 b2.67 V43/IV
+m58 b1 IV b2.33 viio6/IV b2.67 V65/VII
+m59 b1 C: I b2.67 V7/IV
+m60 b1 IV
+m61 b1 IV6
+m62 b1 V6/V
+m63 b1 V65/iii
+m64 b1 viio6/vi b1.67 iii64 b2 V/iii b2.33 viio/vii b2.67 V65/iii
+m65 b1 e: i b2 viio65/III
+m66 b1 V65 b1.67 i b2.33 iio b2.67 iv
+m67 b1 V7 b2 i
+m68 b1 i b1.33 viio b1.67 viio64/III b2 iv b2.33 V b2.67 iv
+m69 b1 i6 b2 V6/III
+m70 b1 VI6 b2 V/III b2.67 III6
+m71 b1 V/III b1.33 viio6 b1.67 viio/III b2 III b2.67 V
+m72 b1 VI b2.67 G: I
+m73 b1 None b1.33 V/V b1.67 V7 b2 I b2.67 iii
+m74 b1 ii6 b1.67 None b2 V2 b2.67 I6
+m75 b1 IV b1.33 viio6 b1.67 I b2 V65
+m76 b1 I b1.67 vi6 b2.67 V6
+m77 b1 ii b2 V b2.67 I6
+m78 b1 ii b2 V
+m79 b1 ii b1.67 viio b2 I6 b2.67 vi
+m80 b1 ii43/IV b2 V7/IV
+m81 b1 C: V b2.67 viio64
+m82 b1 I6
+m83 b1 I b2.67 viio/IV
+m84 b1 ii b1.67 viio/ii b2 viio/V b2.33 V b2.67 V/vi
+m85 b1 viio/iii b1.33 viio/vi b1.67 vi b2 IV b2.33 viio6/IV b2.67 None
+m86 b1 viio7/IV b1.33 V b1.67 V43/V b2 V65 b2.33 I b2.67 V/V/V
+m87 b1 V43/vi b1.33 V65/ii b1.67 ii b2 v
+m88 b1 V65/IV b2 IV
+m89 b1 None b2 I6
+m90 b1 V6/ii b2 ii
+m91 b1 V7/IV
+m92 b1 IV6 b2 I6 b2.33 viio64 b2.67 viio6/IV
+m93 b1 IV6 b2 v6
+m94 b1 I64 b1.67 IV6 b2 v b2.33 viio/IV b2.67 IV
+m95 b1 V43/IV b2 F: I
+m96 b1 I b1.33 viio6
+m97 b1 I
+m98 b1 vi6
+m99 b1 V
+m100 b1 V7/vi b2.67 iii
+m101 b1 IV
+m103 b1 It/vi b2 vi64
+m104 b1 V7/vi b2 vi64
+m105 b1 V7/vi b2.67 vi64
+m106 b1 iio/ii
+m107 b1 g: Ger7
+m108 b1 i64
+m109 b1 viio7/V
+m110 b1 V7/IV/IV
+m111 b1 IV64/IV b2 V65/ii/IV
+m112 b1 ii/IV b1.67 V65/IV b2 C: I
+m113 b1 ii65 b2 viio/V
+m114 b1 V
+m115 b1 I64 b2.67 V7/IV
+m116 b1 IV b2 I64
+m117 b1 vi b1.67 V7 b2 I64
+m118 b1 viio2/V
+m119 b1 V
+m120 b1 v6
+m121 b1 vi6
+m122 b1 vi6
+m123 b1 ii
+m124 b1 I
+m125 b1 v b2 V
+m126 b1 vi64
+m127 b1 vi b2 V/V/V
+m128 b1 V6/V b2 V
+m129 b1 I b2 IV6
+m130 b1 V/V b2 V6
+m131 b1 V/vi b2 vi6
+m132 b1 ii b2 ii6
+m133 b1 V b2 V6
+m134 b1 I b2 I6
+m135 b1 IV b2 IV6
+m136 b1 viio b2 viio6
+m137 b1 G: iii b2 iii6
+m138 b1 vi b2 vi6
+m139 b1 ii b2 ii6
+m140 b1 V b2 V6
+m141 b1 I b2 vi
+m142 b1 ii b2 viio
+m143 b1 iii b2 I
+m144 b1 IV b2 ii
+m145 b1 viio6 b2 viio
+m146 b1 V
+m147 b1 v b2 V
+m148 b1 I64
+m149 b1 i64 b2 I64
+m150 b1 IV b2 V64/V
+m151 b1 V b2.67 V2
+m152 b1 I6
+m153 b1 V7 b1.67 I
+m154 b1 V7 b1.67 I6 b2.33 ii7
+m155 b1 V65 b1.67 I b2 ii6 b2.67 V
+m156 b1 I
+m157 b1 i6 b2 ii
+m158 b1 IV b2 iii
+m159 b1 V b2 I
+m160 b1 viio64 b2 I
+m161 b1 IV b2 V7
+m162 b1 I

--- a/Corpus/HaydnOp20/op20n3-01.txt
+++ b/Corpus/HaydnOp20/op20n3-01.txt
@@ -1,0 +1,243 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in G Minor - No.1: Allegro con spirito
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 2/4
+m1 b1 g: i b2.5 VI6
+m2 b1 V6 b2.5 V7
+m3 b1 i b2.5 iv
+m4 b1 V b2.5 i64
+m5 b1 V b2.5 VI
+m6 b1 ii65 b2.5 V7
+m7 b1 i
+m8 b2.5 VI
+m9 b1 V6 b2.5 V7
+m10 b1 i b2.5 iv
+m11 b1 III6
+m12 b1 iio b2 III
+m13 b1 iv65
+m14 b1 III64 b2 VII
+m16 b2 V7/III
+m17 b1 III64
+m18 b2.5 V7/III
+m19 b1 III64
+m20 b1 VII
+m21 b1 III64
+m22 b1 VII b2.5 V7/VII
+m23 b1 VII
+m25 b1 V/V/III
+m26 b1 V/III
+m27 b1 Bb: I
+m29 b1 IV64
+m30 b1 I
+m31 b1 IV64
+m32 b1 I
+m33 b1 IV64
+m34 b1 I
+m35 b1 V7/IV
+m36 b1 IV
+m37 b1 V65/ii
+m38 b1 ii
+m39 b1 I
+m40 b1 ii6
+m41 b1 V
+m42 b1 V2
+m43 b1 I6
+m44 b1 V65
+m45 b1 I
+m46 b1 V7
+m47 b1 I
+m48 b1 V7
+m49 b1 I
+m50 b1 V7/IV
+m52 b1 viio65/ii
+m53 b1 ii6 b2 V43/ii
+m54 b1 ii b2 None
+m55 b1 V6 b2 V7
+m56 b1 vi b2 V65/IV
+m57 b1 IV
+m58 b1 I64
+m59 b1 V7
+m60 b1 vi b2 viio6/V
+m61 b1 V b2.5 V7/V
+m62 b1 V b2.5 V7/V
+m63 b1 V b2.5 V7/V
+m64 b1 V
+m65 b1 I6
+m67 b1 V
+m70 b1 V+6/IV
+m71 b1 IV
+m72 b1 ii b2 V
+m73 b1 ii b2 ii6
+m74 b1 vi b2 ii
+m75 b1 ii6 b2 vi
+m76 b1 ii6
+m77 b1 V
+m78 b1 IV
+m79 b1 V6/IV b2 V65/IV
+m80 b1 IV
+m81 b1 viio/ii
+m82 b1 ii6
+m83 b1 I64
+m84 b2 V7
+m85 b1 vi
+m86 b1 V
+m87 b1 I b2 V7/IV
+m88 b1 IV
+m89 b1 viio/ii
+m90 b1 ii6
+m91 b1 It/vi
+m92 b1 V/vi
+m93 b1 viio43/vi
+
+Time Signature: 2/4
+m95 b1 d: iv
+m96 b1 i6 b2.5 VII
+m97 b1 i
+m98 b1 V b2.5 i64
+m99 b1 V7 b2 i64
+m100 b1 V
+m101 b1 V b2 viio7/V
+m102 b1 V
+m103 b1 viio43/V
+m104 b1 V b2 viio/V
+m105 b1 V b2 viio/V
+m106 b1 V
+m108 b1 V/III
+m109 b1 III
+m110 b1 i
+m111 b1 III6
+m112 b1 VI
+m113 b1 V6/iv
+m114 b1 iv
+m115 b1 VI6
+m116 b1 IV/VI
+m117 b1 V6/ii/VI
+m118 b1 ii/VI
+m119 b1 IV6/VI
+m120 b1 IV/IV/VI b2.5 viio7/VI
+m121 b1 VI
+m122 b1 V2/IV/VI
+m123 b1 IV6/VI
+m124 b1 V65/IV/VI
+m125 b1 Eb: I
+m126 b1 V7
+m127 b1 I
+m128 b1 V7
+m129 b1 I b2 V65/IV
+m130 b1 IV
+m131 b1 viio/ii
+m132 b1 ii6
+m133 b1 I64
+m134 b1 V7
+m135 b1 vi b2 V64/IV
+m136 b1 IV
+m137 b1 viio/ii
+m138 b1 ii6
+m139 b1 ii65
+m140 b1 V2
+m141 b1 iii
+m142 b1 V6
+m143 b1 I
+m144 b1 V6/vi
+m146 b1 V/V/vi
+m147 b1 V/vi
+m149 b1 vi
+m150 b1 I6
+m152 b1 iii
+m153 b1 I
+m154 b1 IV6 b2 viio/V
+m155 b1 V b2 viio/vi
+m156 b1 vi b2 iii6
+m157 b1 viio6/iii b2 viio7/iii
+m161 b2.5 V/iii
+m163 b2.75 viio/iii
+m164 b1 iii
+m165 b1 g: i
+m166 b1 V6 b2.5 V7
+m167 b1 i b2.5 iv
+m168 b1 V b2.5 i64
+m169 b1 V b2.5 VI
+m170 b1 iio65 b2.5 V7
+m171 b1 i
+m172 b1 III
+m173 b1 V6
+m174 b1 V b2.5 It
+m175 b1 V
+m176 b1 V b2.5 It
+m177 b1 V
+m178 b1 V/iv b2.5 It/iv
+m179 b1 V/iv
+m180 b1 V/iv b2.5 It/iv
+m181 b1 V/iv b2.5 V2/iv
+m182 b1 c: i b2.5 V64
+m183 b1 i b2.5 V2/iv
+m184 b1 iv6 b2.5 V64/iv
+m185 b1 iv b2.5 iv2
+m186 b1 V65/III b2 III
+m187 b1 VI65 b2 iio
+m188 b1 V65 b2 i
+m189 b1 Ger7 b2 V
+m190 b1 V65/v
+m191 b1 g: i
+m192 b1 N6 b2 viio7/V
+m193 b1 V b2 It
+m194 b1 V b2 It
+m195 b1 V b2 It
+m196 b1 V b2 It
+m197 b1 V
+m199 b1 viio7
+m201 b1 viio43
+m202 b1 i6 b2 viio65
+m203 b1 i b2 i6
+m204 b1 iv
+m205 b1 i64
+m206 b1 V
+m207 b1 It
+m208 b1 V b2.5 V/V
+m209 b1 V b2.5 V/V
+m210 b1 V b2.5 V/V
+m211 b1 V
+m212 b1 viio43
+m214 b1 iv
+m217 b1 viio43
+m218 b1 i6 b2 i6
+m219 b1 i b2 VI
+m220 b1 iv b2 N6
+m221 b1 iv/iv b2 V64/iv
+m222 b1 V43/iv b2 V/iv
+m223 b1 iv6 b2 iv6
+m224 b1 iv64 b2 iv6
+m225 b1 Ger7 b2 viio7/V
+m226 b1 i b2 V7
+m227 b1 iv b2 ii
+m228 b1 V6 b2 V
+m229 b1 V7 b2 V6
+m230 b1 V b2 V7
+m231 b1 V6 b2 V
+m232 b1 V7
+m233 b1 V7
+m236 b1 viio43
+m238 b1 i64
+m239 b1 V7
+m240 b1 VI
+m241 b1 V
+m242 b1 V7/iv
+m243 b1 iv
+m244 b1 N6
+m247 b1 viio7/V
+m249 b1 i64
+m250 b1 V7
+m251 b1 i
+m252 b1 III
+m253 b1 V6 b2.5 VI6
+m254 b1 V6 b2.5 VI6
+m255 b1 V6 b2.5 VI6
+m256 b1 V6 b2.5 VI6
+m257 b1 V6 b2.5 viio7/V
+m259 b2.5 viio7
+m265 b2 V43
+m268 b1 i
+m269 b1 V7
+m270 b1 i

--- a/Corpus/HaydnOp20/op20n3-02.txt
+++ b/Corpus/HaydnOp20/op20n3-02.txt
@@ -1,0 +1,90 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in G Minor - No.2: Menuetto: Allegretto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m1 b1 g: i b2 iio b3 i6
+m2 b1 iv b3 i6
+m3 b1 viio6 b3 V43
+m4 b1 viio65
+m5 b1 V43
+m6 b1 i b2 iio b3 i6
+m7 b1 iv b3 VII
+m8 b1 III b2 v b3 viio7/ii
+m9 b1 v b3 V7/V
+m10 b1 v
+m11 b1 Bb: I b2 viio6 b3 I6
+m12 b1 IV b3 I6
+m13 b1 ii b2 viio6/ii b3 ii6
+m14 b1 V b3 ii6
+m15 b1 iii b2 ii6 b3 iii6
+m16 b1 vi b3 V64/V
+m17 b1 V
+m18 b1 V7
+m19 b1 viio43
+m20 b1 V2
+m21 b1 ii
+m22 b1 I6 b2 viio6 b3 I
+m23 b1 I64 b3 V7
+m24 b1 I
+m25 b1 IV/V
+m26 b1 V64
+m27 b1 V6
+m28 b1 IV6/V b3 V
+m31 b1 viio7/V/vi
+m32 b1 V/vi
+m33 b1 g: i b2 ii b3 i6
+m34 b1 iv b3 i6
+m35 b1 viio6 b3 V43
+m36 b1 viio65
+m37 b1 V43
+m38 b1 iv
+m39 b1 VII b3 VI
+m40 b1 V65 b3 i
+m41 b1 N6
+m42 b2 viio7/V
+m43 b1 i64 b3 V7
+m44 b1 V/iv
+m45 b1 iv64
+m46 b1 iv64 b2 V/iv b3 V7/iv
+m47 b3 viio7
+m48 b1 V/iv b2 VI b3 V7/iv
+m49 b3 viio7
+m50 b1 V/iv b2 VI b3 V7/iv
+m51 b3 viio7
+m52 b1 V/iv
+m53 b1 Eb: I
+m55 b1 ii b2 viio b3 I
+m56 b1 V b3 V2
+m57 b1 I6
+m58 b1 I
+m59 b1 V6
+m60 b1 V43/V b3 V7/V
+m61 b1 V
+m62 b1 I b2 V6 b3 V7/V
+m63 b1 V
+m64 b1 I b2 V6 b3 V7/V
+m65 b1 V b3 V65
+m66 b1 I+ b2 vi6 b3 vi
+m67 b1 V6 b3 V
+m68 b1 I7 b2 V64/ii b3 V65/V/V
+m69 b1 V/V
+m70 b1 V65/V
+m71 b1 V b3 V7/V
+m72 b1 V
+m73 b1 f: iio b3 V7
+m74 b1 i6 b3 i
+m75 b1 V65
+m76 b1 i b3 i2
+m77 b1 V65/VII
+m78 b1 VII b3 VII7
+m79 b1 III7
+m80 b1 iio7/v
+m81 b1 viio7/v
+m82 b1 v b3 It/v
+m83 b1 V/v b3 v
+m84 b1 V/v b3 v6
+m85 b1 V/v b3 v6
+m86 b1 V7 b3 v
+m87 b1 V/v

--- a/Corpus/HaydnOp20/op20n3-03.txt
+++ b/Corpus/HaydnOp20/op20n3-03.txt
@@ -1,0 +1,111 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in G Minor - No.3: Poco adagio
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m1 b1 G: I
+m2 b1 V65 b3 I
+m3 b1 IV b2 V2 b3 I6
+m4 b1 V65 b2 I
+m5 b1 ii6 b2 ii b3 vi6
+m6 b1 V6 b2 V7 b3 vi b3.5 I6
+m7 b1 IV b2 I64
+m8 b1 I
+m10 b1 V65 b3 I
+m11 b1 IV b2 V43 b3 I6
+m12 b1 V65 b2 I
+m13 b1 I64
+m14 b1 V
+m15 b1 V7/V
+m16 b1 V64
+m17 b1 vi6
+m18 b1 V/V
+m19 b3 V64
+m20 b1 V7/V b3 V64
+m21 b1 V7/V b3 V64
+m22 b1 V7/V b3 V64
+m23 b1 I b2 vi
+m24 b1 V6
+m25 b1 I b2 V7/V
+m26 b1 iii b3 V64/V/V
+m27 b1 V/V
+m28 b1 V7/V
+m29 b1 V65/V
+m30 b1 D: I
+m31 b1 IV6
+m32 b1 ii6
+m33 b1 V65 b3 I
+m34 b1 V65 b3.33 I
+m35 b1 V65 b3 I
+m36 b1 IV64 b2 I
+m37 b1 IV64 b2 I
+m38 b1 IV
+m40 b3 V7
+m41 b1 I b3 V7
+m42 b1 I b3 V7
+m43 b1 I
+m44 b1 I
+m45 b1 V65
+m46 b1 IV
+m47 b1 V65
+m48 b1 d: i
+m50 b1 V65/v
+m51 b1 a: i
+m52 b1 V7
+m53 b1 iv6
+m54 b1 V64
+m55 b1 i
+m56 b1 V2/iv
+m57 b1 V7/ii b2 viio7/ii
+m58 b1 v/v
+m59 b1 V2/v
+m60 b1 v6
+m61 b1 viio7
+m62 b1 i
+m63 b1 Ger7
+m64 b1 V
+m66 b1 C: I
+m67 b1 V6 b3 I
+m68 b1 IV b2 V2 b3 I6
+m69 b1 V65 b2 I
+m70 b1 I
+m71 b1 iv6/ii
+m72 b1 V7/ii
+m73 b1 ii
+m75 b1 vi6
+m76 b1 V7/iii
+m77 b1 iii
+m78 b1 V65
+m79 b1 I
+m80 b1 V65/vi
+m81 b1 vi
+m82 b1 ii65
+m83 b1 V b3 V43/V/V
+m84 b1 G: V
+m85 b1 I6 b1.5 V43 b2 I b2.5 V7 b3 I6 b3.5 I
+m86 b1 V
+m87 b1 I6 b1.5 V43 b2 I b2.5 V7 b3 I6 b3.5 I
+m88 b1 V
+m89 b1 V b3 I64
+m90 b1 V7 b3 I64
+m91 b1 V7 b3 I64
+m92 b1 V7 b3 I64
+m93 b1 ii6
+m94 b1 I6
+m96 b1 IV b2 I64 b3 V
+m97 b1 vi b3 V43/V
+m98 b1 V7
+m100 b1 I
+m101 b1 vi
+m102 b1 IV
+m103 b1 V65 b3 I
+m104 b1 V65 b3 I
+m105 b1 V65 b3 I
+m106 b1 IV64 b2 I
+m107 b1 IV64 b2 I
+m108 b1 IV
+m110 b3 V7
+m111 b1 I b3 V7
+m112 b1 I b3 V7
+m113 b1 I

--- a/Corpus/HaydnOp20/op20n3-04.txt
+++ b/Corpus/HaydnOp20/op20n3-04.txt
@@ -1,0 +1,102 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in G Minor - No.4: Allegro di molto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 g: i b3 V2
+m2 b1 i6 b3 viio6
+m3 b1 V7
+m5 b1 i b3 V2
+m6 b1 i6 b3 V2
+m7 b1 i6
+m8 b2 Ger7 b3 V65
+m9 b1 i b2.5 VI b3 N6
+m10 b1 V b3 i
+m11 b1 i b3 V2
+m12 b1 i6
+m13 b1 VI b3 VI7
+m14 b1 viio7/III
+m15 b1 V65/III b3 III
+m16 b1 V65/III b3 III6
+m17 b1 V43/V/III b3 V/III
+m18 b1 Bb: I b3 V65
+m19 b1 I b3 V65
+m20 b1 I b3 V43
+m21 b1 I6 b3 IV
+m22 b1 ii6
+m24 b1 viio65/V
+m25 b1 V
+m26 b4 V2
+m27 b1 V65/IV b3 IV
+m28 b1 iio b3 V7
+m29 b1 I6 b3 V7
+m30 b1 I6 b3 V7
+m31 b1 I b3 V7
+m32 b1 V7 b3 V65/vi
+m33 b1 vi b3 viio7/V
+m34 b1 V7 b3 vi
+m35 b1 V7/IV
+m36 b1 IV b3 ii
+m37 b1 I64 b3 V7
+m38 b1 I b3 V7
+m39 b1 I b3 V7
+m40 b1 I b3 V7
+m41 b1 I b3 V7
+m42 b1 I
+m43 b1 I b3 V64
+m44 b1 I64 b3 V43
+m45 b1 I64 b3 V7/V
+m46 b1 V b3 V7/V
+m47 b1 c: IV
+m48 b1 viio7
+m49 b1 i6 b3 viio7
+m50 b1 i6 b3 viio7
+m51 b1 i b3 V7/VI
+m52 b1 VI b3 viio7/iv
+m53 b1 iv
+m54 b1 V b3 V2
+m55 b1 i6 b3 V65
+m56 b1 i
+m57 b1 V65/III
+m59 b1 III b3 V2/III
+m60 b1 III6 b3 V2/III
+m61 b1 III6
+m62 b1 viio65/iv
+m63 b1 iv6
+m64 b1 viio65/v
+m65 b1 v6
+m66 b1 V6
+m67 b1 i
+m68 b1 VI
+m69 b1 V65/V
+m71 b1 g: i b3 V2
+m72 b1 i6 b3 viio6
+m73 b1 V7
+m75 b1 i b3 V2
+m76 b1 i6 b3 V2
+m77 b1 i6 b3 V65/iv
+m78 b1 iv b3 V65/iv
+m79 b1 i
+m80 b1 VI b4 VI7
+m81 b1 Ger7/VI
+m82 b1 V/VI b3 viio7/iv
+m83 b1 iv b3 viio7/V
+m84 b1 V b3 V7
+m85 b1 viio7
+m89 b4 V65
+m90 b1 i b4.5 V7
+m91 b1 i6 b3 viio7
+m92 b1 i6 b3 viio7
+m93 b1 i b3 V7
+m94 b3 VI
+m95 b1 N6 b3 viio7/V
+m96 b1 V b3 i6
+m97 b1 i64 b3 V7
+m98 b1 i b3 V7
+m99 b1 i b3 V7
+m100 b1 i b3 viio6/iv
+m101 b1 iv64 b3 viio7
+m102 b1 i b3 viio/iv
+m103 b1 iv64 b3 V7
+m104 b1 I

--- a/Corpus/HaydnOp20/op20n4-01.txt
+++ b/Corpus/HaydnOp20/op20n4-01.txt
@@ -1,0 +1,244 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in D Major - No.1: Allegro di molto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m1 b1 D: I
+m3 b1 V7
+m4 b1 I b2 viio7 b3 I
+m9 b1 IV64
+m10 b1 I
+m11 b1 iii b3 V65
+m12 b1 I
+m15 b1 V7
+m16 b1 I b2 viio7 b3 I
+m19 b1 ii
+m20 b3 ii2
+m21 b1 V65
+m22 b1 ii65
+m23 b1 I64 b3 V7
+m24 b1 vi
+m25 b1 IV/IV
+m26 b1 V65/IV b3 IV
+m27 b1 ii
+m28 b1 V6/ii b2 ii b3 viio7
+m29 b1 I b3 V7
+m30 b1 I
+m31 b1 vi
+m34 b1 V43/V
+m35 b1 V
+m37 b1 a: i
+m39 b1 Ger7
+m41 b1 V b3 viio/V
+m42 b1 V
+m43 b1 A: I6
+m44 b1 V
+m45 b1 I b2 IV b3 viio/V
+m46 b1 V
+m47 b1 I
+m48 b1 ii
+m49 b1 V2 b3 I6
+m50 b1 V7 b3 I
+m51 b1 V2 b3 I6
+m52 b1 V7 b3 I
+m53 b1 ii65
+m54 b1 V2
+m55 b1 I6
+m56 b1 IV
+m57 b1 ii6
+m58 b1 I6
+m61 b1 V43
+m63 b1 I6
+m64 b1 None b3 I6
+m65 b1 V43 b3 I
+m66 b1 ii6 b3.67 V7
+m67 b1 I
+m68 b1 vii/ii
+m69 b2 ii b3 IV
+m70 b1 iii6 b3 V7
+m71 b1 I
+m73 b2 I6
+m74 b2 viio65/ii
+m75 b1 ii6
+m76 b1 V2
+m78 b1 I6
+m79 b1 V65
+m80 b1 I6
+m81 b1 V2
+m82 b1 I6
+m83 b1 IV/IV
+m84 b1 IV
+m85 b1 viio/ii b3 ii
+m86 b1 I64 b3 V7
+m87 b1 I
+m89 b1 IV
+m90 b1 viio/ii b3 ii
+m91 b1 V65 b3 I
+m92 b1 ii6
+m93 b1 V2
+m95 b1 I6
+m96 b1 IV
+m97 b2 viio6/V
+m98 b1 V7
+m99 b1 I
+m102 b1 I64 b3 V7
+m103 b1 I
+m106 b1 I64 b3 V7
+m107 b1 I
+m112 b2 viio7/IV
+m113 b3 viio/ii
+m114 b1 V
+m116 b1 V7
+m117 b1 i64
+m118 b1 V7
+m119 b1 i64
+m120 b1 V7
+m121 b3 viio/V/ii
+m122 b1 f#: V
+m124 b1 V7
+m125 b1 i64
+m126 b1 V7
+m127 b1 i64
+m128 b1 V7
+m129 b1 i64
+m130 b1 V
+m132 b1 V/VI
+m133 b1 viio/VI
+m134 b1 D: I
+m136 b1 V7
+m137 b2 viio7 b3 I
+m138 b1 I b3 viio
+m139 b1 I b3 IV64
+m140 b1 viio7/II b3 iii64/II
+m141 b1 E: I b3 viio6
+m142 b1 I b3 IV
+m143 b1 I b3 IV64
+m144 b1 viio7/II b3 iii64/II
+m145 b1 F#: I b3 viio6
+m146 b1 I b3 iv64
+m147 b1 I b3 iv
+m148 b1 V7/iv
+m149 b1 b: i
+m151 b1 V2/iv
+m153 b1 iv6
+m155 b1 V65/iv
+m157 b1 iv
+m158 b1 V2/VII
+m159 b1 V7/V
+m161 b1 V
+m163 b1 V7/v
+m164 b1 v b2 i64 b3 v
+m165 b3 i64
+m166 b1 v
+m167 b1 V7
+m168 b1 V2
+m169 b1 i6
+m170 b1 V65
+m171 b1 i
+m172 b1 Ger7
+m173 b1 V
+m175 b1 V7 b3 i
+m176 b1 V2 b3 i6
+m177 b1 V7 b3 i
+m178 b1 iv7
+m179 b1 III7
+m180 b1 iio7
+m181 b1 i b3 None
+m182 b1 V65/iv b2 IV b3 iv
+m183 b1 V b2 None b3 IV6
+m184 b1 V65 b2 i b3 V64
+m185 b1 i6 b2 V65/iv
+m186 b1 iv b2 viio/V
+m187 b1 i64 b3 V7
+m188 b1 i
+m189 b1 viio43 b3 i6
+m191 b1 viio43/iv/iv b3 iv6/iv
+m193 b1 viio43/III/iv b3 III6/iv
+m195 b1 viio43/iv b3 iv
+m196 b1 e: i
+m197 b1 viio7/VII b3 VII
+m199 b1 viio7/v b3 v
+m200 b1 viio7/iv b3 iv
+m201 b1 V65/III b3 III
+m202 b1 V65/ii b3 ii
+m203 b1 V65 b3 i
+m204 b1 V
+m207 b1 G: I
+m209 b1 viio
+m210 b1 I
+m214 b1 V43/vi
+m215 b1 vi b2 V65/V
+m217 b1 D: I
+m219 b1 V7
+m220 b1 I b2 IV64 b3 I
+m221 b1 I b3 IV64
+m222 b1 I
+m223 b1 ii
+m224 b3 ii2
+m225 b1 V65
+m226 b1 IV b3 ii6
+m227 b1 I64 b3 V7
+m228 b1 vi
+m229 b1 IV/IV
+m230 b1 V65/IV b3 IV
+m231 b1 ii
+m232 b1 V6/ii b2 ii b3 viio7
+m233 b1 I b2 ii6 b3 viio7/V
+m234 b1 V
+m236 b1 V7 b3 I
+m237 b1 V2 b3 I6
+m238 b1 V7 b3 I
+m239 b1 IV7
+m240 b1 V2
+m241 b1 I6
+m242 b1 IV
+m243 b1 ii
+m244 b1 I6
+m246 b1 ii65 b2 V43
+m249 b1 I6 b3 V7/IV
+m250 b1 IV b3 I6
+m251 b1 V43 b3 I
+m252 b1 ii6 b3 V7
+m253 b1 I
+m254 b1 viio/ii
+m255 b2 ii
+m256 b1 I64 b3 V7
+m257 b1 I
+m260 b2 viio65/ii
+m261 b1 ii6
+m262 b1 V2
+m264 b1 I6
+m265 b1 V2
+m266 b1 I6
+m267 b1 V2
+m268 b1 I6
+m269 b1 IV/IV
+m270 b1 IV
+m271 b1 viio/ii b3 ii
+m272 b1 V43/IV
+m273 b1 V/IV
+m275 b1 IV
+m276 b1 viio/ii b3 ii
+m277 b1 viio7 b3 I
+m278 b1 viio/ii
+m279 b1 V2
+m281 b1 I
+m282 b2 IV
+m284 b1 I64 b3 V7
+m285 b1 I b2.33 IV
+m286 b1 iii b2 ii
+m287 b1 I b2 ii
+m288 b1 I64 b3 V7
+m289 b1 I
+m290 b1 IV b2 V
+m291 b1 I b2 ii
+m292 b1 I64 b3 V7
+m293 b1 I b3 iii
+m294 b1 I6
+m297 b1 I6 b2 I
+m298 b3 N/vi
+m299 b1 I b3 iii
+m300 b1 I
+m301 b3 iii
+m302 b1 I

--- a/Corpus/HaydnOp20/op20n4-02.txt
+++ b/Corpus/HaydnOp20/op20n4-02.txt
@@ -1,0 +1,149 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in D Major - No.2: Un poco Adagio affettuoso
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 2/4
+m0 b2.5 d: V
+m1 b1 i b2 viio6 b2.5 i
+m2 b1 V2 b1.5 i6 b2 VI
+m3 b1 i6 b1.5 VI b2 iio6
+m4 b1 i b2.5 V
+m5 b1 i b2 viio b2.5 i
+m6 b1 iv7 b2 -VII7
+m7 b1 VI6 b1.5 VI b2 V/III b2.5 V7/III
+m8 b1 III
+
+Time Signature: 2/4
+m0 b2.5 V
+m9 b1 III b2 iv b2.5 v
+m10 b1 iv6 b1.5 viio43/iv b1.88 iv6
+m12 b1 V b2.5 V/iv
+m13 b1 N6
+m14 b1 viio65/iv
+m15 b1 iv6
+m16 b1 Ger7
+m17 b1 i64
+m18 b1 i
+
+Time Signature: 2/4
+m0 b2.5 V
+m19 b1 i
+m20 b1 viio43 b2.5 viio43
+m21 b1 i6 b1.5 VI b2 iio65 b2.5 V7
+m22 b1 i
+m23 b1 i b1.5 i6 b2 viio6 b2.5 i
+m24 b1 iv7 b2 VII
+m25 b1 III b2 III64
+m26 b1 III
+
+Time Signature: 2/4
+m0 b2.5 V
+
+Time Signature: 2/4
+m0 b2.5 V
+m27 b1 III
+m28 b1 iv6
+m29 b1 VI
+m30 b1 i64 b2 V b2.5 V6/iv
+m31 b1 iv
+m32 b1 viio65/iv
+m33 b1 iv
+m34 b2 viio65/V
+m35 b1 i64
+m36 b1 V b2 i
+
+Time Signature: 2/4
+m0 b2.5 V
+m37 b1 i b2 viio b2.5 i
+m38 b1 viio2 b1.5 i64 b2 V b2.5 V7
+m39 b1 VI b2 viio64
+m40 b1 i6
+m41 b1 i b2 viio6 b2.5 i
+m42 b1 iv7 b2 V7/III
+m43 b1 III6 b1.5 iv64 b2 III b2.5 V7/III
+m44 b1 III
+
+Time Signature: 2/4
+m0 b2.5 V
+m45 b1 viio64/iv b2 iv6 b2.5 viio7/iv
+m46 b1 iv
+m47 b1 iio64
+m48 b1 i b2 V6 b2.5 V6/iv
+m49 b1 iv
+m50 b1 v
+m51 b1 VI
+m52 b1 Ger7
+m53 b1 i64 b2.5 V65
+m54 b2 i
+
+Time Signature: 2/4
+m0 b2.5 V
+m55 b1 i b1.5 i6 b2 V43 b2.5 i
+m56 b1 iv b1.5 i6 b2 None b2.5 viio64
+m57 b1 i6 b1.5 VI b2 iv b2.5 V
+m58 b1 i
+m59 b1.5 i6 b2 V64 b2.5 i
+m60 b1 VI64 b2 V7/III
+m61 b1 III b1.5 VI b2 V/III
+m62 b1 III
+
+Time Signature: 2/4
+m0 b2.5 V
+m63 b1.5 viio7/iv b2 iv b2.5 viio65/iv
+m64 b1 iv6 b1.5 iv/iv b2 iv
+m65 b2 viio65/V
+m66 b1 V b2.5 V6/iv
+m67 b1 N6
+m68 b1 viio65/iv
+m69 b1 iv6
+m70 b1 Ger7
+m71 b1 i64 b2 V
+m72 b1 i
+
+Time Signature: 2/4
+m0 b2.5 V
+m73 b1 i b2 viio6 b2.5 i
+m74 b1 V2 b1.5 i6 b2 VI
+m75 b1 i6 b1.5 VI b2 iio65
+m76 b1 i b2.5 V
+m77 b1 i b2 viio b2.5 i
+m78 b1 iv7 b2 -VII7
+m79 b1 III b1.5 VI b2 V/III
+m80 b1 III
+m81 b1 III b2 iv b2.5 v
+m82 b1 iv6 b1.5 viio43/iv b2 iv6
+m84 b1 V b2.5 V/iv
+m85 b1 N6
+m86 b1 viio65/iv
+m87 b1 iv6
+m88 b1 Ger7
+m89 b1 i64
+m91 b2.5 viio64
+m93 b1 viio7
+m94 b1 i b2 VI
+m95 b1 ii7/VI b2 V7/VI
+m96 b1 iv6
+m97 b1 iv64/iv b2 V65/iv
+m98 b1 iv b2 N6
+m99 b1 iii7 b2 VI7
+m100 b1 N b2 V65/III
+m101 b1 III7 b2 V65/iv
+m102 b1 iv b2 N6
+m103 b1 viio43
+m105 b1 viio7/V
+m107 b1 V b2 viio64
+m108 b1 i6 b2 V65
+m109 b1 i b2 VI
+m110 b1 i64 b2.5 viio7/V
+m111 b1 V b1.5 viio65/V b2 V6 b2.5 V43/III
+m112 b1 i6 b1.5 V65 b2 i b2.5 viio43/iv
+m113 b1 iv6 b1.5 V65/iv b2 iv b2.5 viio7/V
+m114 b1 V b2 VI6 b2.5 viio6/V
+m115 b1 V6 b1.5 V7 b2 VI b2.5 i6
+m116 b1 N6
+m118 b1 viio7/V
+m119 b1 V7
+m120 b1 VI
+m121 b1 iv b2 V
+m122 b1 i

--- a/Corpus/HaydnOp20/op20n4-03.txt
+++ b/Corpus/HaydnOp20/op20n4-03.txt
@@ -1,0 +1,39 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in D Major - No.3: Menuetto alla zingarese
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m0 b3 D: V
+m1 b1 I b2 V6
+m2 b1 I b2 IV b3 ii6
+m3 b1 V7
+m4 b3 V7/V
+m5 b1 V
+m6 b1 V/V b2 V b3.5 V/V
+m7 b1 V b2 vi6 b3 V7/V
+m8 b1 I
+m9 b1 I6 b2 ii
+m10 b1 I b2 IV
+m11 b1 ii
+m12 b2 V
+m13 b1 I
+m16 b3 V43
+m17 b1 I
+m18 b1 V7 b2 I b3 V7
+m19 b1 I b2 ii b3 V7
+m20 b1 I
+m21 b1 I b2 vi b3 I6
+m22 b1 ii65
+m23 b1 viio6 b2 V7 b3 V43
+m24 b1 vi6
+m25 b1 I b2 I64 b3 viio7/V
+m26 b1 V
+m27 b1 vi6 b3 V/V
+m28 b1 V
+m31 b3 I6
+m32 b1 V6
+m33 b1 I b2 vi b3 I6
+m34 b1 ii65
+m35 b1 ii b2 I6 b3 V
+m36 b1 I

--- a/Corpus/HaydnOp20/op20n4-04.txt
+++ b/Corpus/HaydnOp20/op20n4-04.txt
@@ -1,0 +1,128 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in D Major - No.4: Presto e scherzando
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 D: I b3 viio
+m2 b1 I6 b2 viio7/ii b3 ii
+m3 b1 ii b3 i6
+m4 b1 V b2 viio6/V b3 V6
+m5 b1 ii b3 I6 b4 I6
+m6 b1 IV b2 V7 b3 I
+m7 b1 V b2.75 viio/V b3 V
+m8 b1 III+64/i
+m10 b1 i b4.5 V7/v
+m11 b1 V6 b3 V
+m12 b1 I b3 viio
+m13 b1 I6 b2 viio7/ii b3 ii
+m14 b1 ii6 b3 V65/ii
+m15 b1 ii b3 V2/V
+m16 b1 V6 b2.5 V65 b3 i b4 ii6 b4.5 viio/ii
+m17 b1 ii b2 ii6 b2.5 viio/ii b3 ii b4 ii6 b4.5 ii
+m18 b1 I64 b3 V
+m19 b1 A: I b2 V7 b3 I6 b4 V7
+m20 b1 I6
+m21 b1 I
+m22 b1 a: i
+m23 b1 VI
+m24 b2 V65/VI
+m25 b4 VI
+m26 b4 Ger7
+m28 b1 V
+m29 b1 V
+m30 b1 V
+m31 b1 IV
+m32 b2 viio b3 V65
+m33 b1 A: I b3 IV b4 IV+
+m34 b1 ii6 b2 V6/V b3 V b4 V+
+m35 b1 iii6 b2 V6/vi b3 vi b4 ii64
+m36 b1 IV6 b3 viio b4 vii
+m37 b1 V6 b3 I
+m38 b1 ii6 b4 I
+m39 b1 V65 b2 I b3 ii6 b4 V
+m40 b1 I b3 ii6 b4 I64
+m41 b1 IV6 b2 I64 b3 IV6 b4 I64
+m42 b1 ii65 b2 I6 b3 ii65 b4 V
+m43 b1 I b3 ii65 b4 I64
+m44 b1 IV6 b2 I64 b3 IV6 b4 I64
+m45 b1 ii65 b2 I6 b3 ii65 b4 V
+m46 b1 I
+m48 b1 V7/IV
+m50 b1 b: viio7 b3 III+64 b4 viio
+m51 b1 i
+m52 b1 V7/III
+m53 b1 V7/VI
+m54 b1 viio7/iv b2 V65/iv
+m55 b1 iv b3 iio6 b4 viio7/V
+m56 b1 V
+m57 b1 i6 b2 V2 b3 V65
+m58 b1 i b3 V/iv
+m59 b1 iv6 b2 V2/iv b3 V65/iv
+m60 b1 iv b3 V/VII
+m61 b1 VII6 b2 V2/VII b3 V65/VII
+m62 b1 VII b3 V/III
+m63 b1 III6 b2 V2/III b3 V65/III
+m64 b1 III b3 V/VI
+m65 b1 VI b2 V2/VI b3 V65/VI
+m66 b1 VI
+m67 b4 It
+m68 b1 V b4 viio43
+m69 b4 viio43
+m71 b2 i6 b3 iio65 b4 V
+m72 b1 VI b2 i6 b3 iio65 b4 V
+m73 b1 i b2 i6 b3 iio65 b4 V
+m74 b1 VI b2 i6 b3 iio65 b4 V
+m75 b1 i
+m76 b1 VI6 b3 iio
+m77 b1 VII6 b3 III
+m78 b1 V6/iv b3 iv
+m79 b1 V65/III
+m81 b1 D: I b3 viio
+m82 b1 I6 b2 viio7/ii b3 ii
+m83 b1 ii b3 i6
+m84 b1 V b2 viio6/V b3 V6
+m85 b1 ii b3 I6 b4 I6
+m86 b1 IV b2 V7 b3 I
+m87 b1 V b2.75 viio/V b3 V
+m88 b1 III+64/i
+m90 b1 i b4.5 V7/V
+m91 b1 V b2 V6 b3 i b4 V43
+m92 b1 i6 b2 V65 b3 i b4 i6
+m93 b1 V b2 V6 b3 i b4 V7
+m94 b1 i6 b2 V65 b3 i b4 i6
+m95 b1 V
+m96 b1 I b2 V7 b3 I6 b4 V7
+m97 b1 I6
+m98 b1 I
+m99 b1 d: i
+m100 b1 VI
+m101 b2 III65
+m102 b4 VI
+m103 b4 Ger7
+m104 b4 iv6
+m105 b1 V
+m106 b1 V
+m107 b1 V
+m108 b1 iv
+m109 b3 V7
+m110 b1 D: I b3 IV b4 IV+
+m111 b1 ii6 b2 V6/V b3 V b4 V+
+m112 b1 iii6 b2 V6/vi b3 vi b4 IV6
+m113 b1 IV6 b3 viio b4 vii
+m114 b1 V6 b3 I
+m115 b1 IV b4 I
+m116 b1 V65 b2 I b3 ii b4 V7
+m117 b1 I b2 I6 b3 ii65 b4 I64
+m118 b1 IV6 b2 I64 b3 IV6 b4 I64
+m119 b1 ii65 b2 I6 b3 ii65 b4 V
+m120 b1 I b2 I6 b3 ii65 b4 I64
+m121 b1 IV6 b2 I64 b3 IV6 b4 I64
+m122 b1 ii65 b2 I6 b3 ii65 b4 V
+m123 b1 I
+m124 b1 I
+m125 b1 viio7/iv/vi
+m126 b1 iv/vi
+m127 b1 I
+m129 b1 IV64 b4 viio
+m130 b1 viio b3 I

--- a/Corpus/HaydnOp20/op20n5-01.txt
+++ b/Corpus/HaydnOp20/op20n5-01.txt
@@ -1,0 +1,149 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in F Minor - No.1: Moderato
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 f: i
+m2 b1 V7
+m3 b1 i
+m4 b1 iio b3.75 V7
+m5 b1 i
+m6 b1 V7
+m7 b1 i
+m8 b1 iv
+m9 b1 Ger7
+m10 b1 V b3 i b4 V/V
+m11 b1 V b3 i b4 Ger7
+m12 b1 V
+m14 b1 Ab: iii
+m15 b1 IV b4 viio65/ii
+m16 b1 ii b2 V7/ii b3 ii b4 V7/V
+m17 b1 V7
+m18 b2 V7
+m20 b1 I
+m21 b1 V
+m22 b1 IV b3 iii
+m23 b1 ii b3 I
+m24 b1 V
+m25 b1 V b3 V7/V
+m26 b1 V b3 V7/V
+m27 b1 V
+m28 b1 I b3 ii7
+m30 b1 V7 b3 I
+m31 b1 ii b2 V7 b3 I
+m32 b1 ii7
+m34 b1 ab: viio7/V
+m35 b1 V
+m37 b3 V2
+m38 b1 Ab: I6 b3 V7
+m39 b1 I b2 V7 b3 I b4 V7
+m40 b1 I
+m41 b1 IV
+m42 b1 I64 b3 V7
+m43 b1 vi b3 iii
+m44 b1 ii b3 I
+m45 b1 V7 b2 I b3 ii b4 I64 b4.5 V7
+m46 b1 I b3 iv
+m47 b1 I b3 iv
+m48 b1 I b3 viio7/vi
+m49 b1 I b2 IV b3 viio7 b4 V7/IV
+m50 b1 Db: I
+m51 b1 V6
+m52 b1 I7
+m53 b1 V7/ii
+m54 b1 ii
+m55 b1 V/V/V
+m56 b1 V7/V
+m57 b1 Ab: I
+m58 b1 V
+m59 b1 I b3 V7
+m60 b1 I b3 V7
+m61 b1 Db: V
+m63 b1 V/IV/iii
+m64 b1 IV/iii
+m66 b1 V/V/iii
+m67 b1 V/iii
+m69 b1 f: i
+m70 b1 V/v
+m72 b3 V2/v
+m73 b1 c: i b3 V65
+m74 b1 i
+m75 b1 iv
+m76 b1 i b3 V7
+m77 b1 i
+m78 b1 V7/VI
+m79 b1 VI
+m80 b1 V7/iv
+m81 b1 f: i
+m82 b1 V7
+m86 b1 i
+m87 b1 V7
+m88 b1 i
+m89 b1 ii6 b4 V7
+m90 b1 i
+m91 b1 V7
+m92 b1 V7/iv
+m93 b1 iv
+m94 b1 V7/IV
+m95 b1 IV7
+m96 b1 V7/V
+m97 b1 V
+m98 b1 V7
+m99 b1 i b3 -VII
+m100 b1 VI7 b3 V7
+m101 b1 VI7
+m102 b1 iv7
+m103 b1 V
+m104 b1 V b3 viio7/V
+m105 b1 V b3 viio7/V
+m106 b1 V b3 V/V
+m107 b1 i b3 ii7
+m109 b1 V65 b3 i
+m110 b1 ii b2 V7 b3 i
+m111 b1 ii7
+m113 b1 viio7/V
+m114 b1 V
+m117 b1 i6
+m118 b1 iv
+m119 b1 viio7/V
+m120 b1 V
+m121 b1 viio7/iv
+m123 b1 iv b2 i64 b3 viio43/V
+m124 b1 V
+m126 b3 V2
+m127 b1 i6 b3 V65
+m128 b1 i b2 V7 b3 i b4 V7
+m129 b1 i
+m130 b1 ii
+m131 b1 i64 b3 V7
+m132 b1 vi b3 iii
+m133 b1 ii b3 i6
+m134 b1 V43 b2 i b3 ii b4 i64 b4.5 V7
+m135 b1 i b3 iv
+m136 b1 i b3 iv
+m137 b1 i b3 V7/VI
+m138 b1 i b3 V7/VI
+m139 b1 Db: I
+m140 b1 V7
+m141 b1 V7/IV
+m142 b1 Gb: I
+m143 b1 V
+m144 b1 i
+m145 b1 V7/III b3 III
+m146 b3 V7
+m147 b1 i b3 V7/V
+m148 b1 V
+m149 b1 f: Ger7
+m150 b1 i64
+m151 b1 V7
+m152 b1 i64
+m153 b1 V7
+m154 b1 i
+m155 b1 iv
+m156 b1 V7 b2 i b3 ii b4 V7
+m157 b1 i
+m158 b1 iv
+m159 b1 V7 b2 i b3 ii b4 V7
+m160 b1 i b3 V
+m161 b1 i

--- a/Corpus/HaydnOp20/op20n5-02.txt
+++ b/Corpus/HaydnOp20/op20n5-02.txt
@@ -1,0 +1,105 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in F Minor - No.2: Menuetto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m1 b1 f: i
+m2 b1 V43
+m3 b1 i6 b2 i b3 viio65/V
+m4 b1 i64 b3 V
+m5 b1 V6
+m6 b1 i
+m7 b1 v6
+m8 b1 iv6 b3 III6
+m9 b1 iv7 b2 iio6 b3 i6
+m10 b1 VII b3 viio7/VII
+m11 b1 VII b2 viio7/VII b3 VII
+m12 b1 V7/III
+m13 b1 III b3 III6
+m14 b1 VI b3 V7/III
+m15 b1 III b3 III6
+m16 b1 VI b3 V7/III
+m17 b1 III
+m18 b1 viio6
+m19 b1 V7/iv
+m20 b1 iv
+m21 b1 viio43/iv
+m22 b1 iv6
+m23 b1 V
+m24 b1 V
+m25 b1 i6 b3 It
+m26 b1 V b2 V6 b3 V64
+m27 b1 i6 b3 It
+m28 b1 V
+m29 b1 viio6
+m30 b1 i
+m31 b1 V43
+m32 b1 i6 b2 i b3 Ger7
+m33 b1 i64 b3 V
+m34 b1 i6 b2 i b3 VI
+m35 b1 i64 b3 V
+m36 b1 V6
+m37 b1 i
+m38 b1 V43
+m39 b1 i6
+m40 b1 V7/VI
+m41 b1 VI
+m42 b1 viio7/iv
+m43 b1 iv b3 V65/V
+m44 b1 V b3 viio7/V
+m45 b1 V b2 viio7/V b3 V
+m46 b1 V7
+m47 b1 viio43
+m48 b1 i b3 i6
+m49 b1 iio65 b3 V7
+m50 b1 i b3 i6
+m51 b1 iio65 b3 V7
+m52 b1 i
+m53 b1 V7
+m54 b1 i
+m55 b1 F: I
+m56 b1 IV64
+m57 b1 I b3 IV64
+m58 b1 I b3 viio
+m59 b1 I
+m60 b1 viio/V
+m61 b1 V6
+m62 b1 viio/V
+m63 b1 vii6/V
+m64 b1 V
+m65 b1 viio/V/V
+m66 b1 V65/V b3 V
+m67 b1 vi
+m68 b1 viio/vi b3 vi
+m69 b1 vi6 b3 V7/V
+m70 b1 V
+m71 b1 V
+m72 b1 viio/V b3 V7
+m73 b1 I64
+m74 b1 V b3 V7
+m75 b1 I64
+m76 b1 V b3 V7
+m77 b1 I64
+m78 b1 V
+m79 b1 I
+m80 b1 IV64
+m81 b1 I b3 IV64
+m82 b1 I b3 viio
+m83 b1 I
+m84 b1 viio
+m85 b1 iv
+m86 b1 viio
+m87 b1 I6
+m88 b1 vii6
+m89 b1 I
+m90 b1 viio/V
+m91 b1 V65 b3 I
+m92 b1 ii6
+m93 b1 ii b3 V7
+m94 b1 I
+m96 b1 iv
+m97 b1 ii
+m98 b1 V65 b3 I
+m99 b1 V6/V b3 V7
+m100 b1 I

--- a/Corpus/HaydnOp20/op20n5-03.txt
+++ b/Corpus/HaydnOp20/op20n5-03.txt
@@ -1,0 +1,90 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in F Minor - No.3: Adagio
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 6/8
+m1 b1 F: I
+m2 b1 ii2
+m3 b1 V65
+m4 b1 I b2.67 V6
+m5 b1 vi b2 ii65
+m6 b1 V7 b2 vi
+m7 b1 IV b2 IV b2.33 viio6/ii b2.67 ii
+m8 b1 I64 b1.67 V7 b2 I
+m9 b1 I
+m10 b1 viio6 b1.67 vi6
+m11 b1 V65
+m12 b1 I
+m13 b1 IV
+m14 b1 V6 b2 I6 b2.67 I
+m15 b1 ii7 b2 V65 b2.67 I
+m16 b1 ii6 b2 I
+m17 b1 I
+m18 b1 viio6/vi b2 vi
+m19 b1 I b2.33 V65/ii
+m20 b1 ii
+m21 b1 V6 b2 vi7 b2.67 V/V
+m22 b1 V b2 V/V
+m23 b1 V6 b2 vi7 b2.67 V/V
+m24 b1 V b1.67 V b2 V/V
+m25 b1 V6 b2.67 V65
+m26 b1 I b2 vi6
+m27 b1 V64 b2 V64 b2.67 V7/V
+m28 b1 V b2 V7/V
+m29 b1 I b2 V7/V
+m30 b1 V
+m31 b1 I6 b2 viio65/ii
+m32 b1 V64 b2 V7/V
+m33 b1 V64 b2 V7/V
+m34 b1 V64
+m35 b1 V b1.33 I6 b1.67 V6 b2 I b2.33 V43/V b2.67 V
+m36 b1 V65/V
+m37 b1 V65/V b1.67 V b2 vi6
+m38 b1 V7/V b1.67 iii b2.33 I
+m39 b1.33 V7/V b2.33 V
+m41 b1 I b1.67 V7/V b2 V
+m42 b1 I
+m43 b1 ii7
+m44 b1 V b2 V7
+m45 b1 V7/IV
+m46 b1 V65/ii
+m47 b1 ii
+m48 b1 V/vi
+m49 b1 vi6
+m50 b1 V6/vi
+m51 b1 vi b2 ii b2.67 V7/vi
+m52 b1 IV b2 ii b2.67 V/vi
+m53 b1 vi b2 V2/ii
+m54 b1 ii6 b2 V2
+m55 b1 I6 b2 V6 b2.67 I
+m56 b1 V7 b2 V
+m57 b1 I
+m58 b1 ii7
+m59 b1 V7
+m60 b1 I
+m61 b1 IV
+m62 b1 ii7 b1.67 V2 b2 I6 b2.67 I
+m63 b1 ii b1.67 ii2 b2.67 I
+m64 b1 ii6 b2 V
+m65 b1 I6 b2 ii7 b2.67 V
+m66 b1 I b2 V b2.67 viio64
+m67 b1 I6 b2 ii7 b2.67 V
+m68 b1 I b2 V b2.33 viio64
+m69 b1 I6 b2.67 V65/IV
+m70 b1 IV b2 ii6
+m71 b1 I64 b2.67 V7
+m72 b1 I b2 V7
+m73 b1 I b2 V7
+m74 b1 I
+m75 b1 vi b2 viio65/V
+m76 b1 I64 b1.33 V7 b1.67 I64 b2 V7
+m77 b1 I64 b1.33 V7 b1.67 I64 b2 V7
+m78 b1 I64 b1.33 V7 b1.67 I64 b2 V7
+m79 b1 I b1.33 IV b1.67 I6 b2 ii65 b2.33 V43 b2.67 I
+m80 b1 V65
+m81 b1 V65 b1.67 I b2 ii64 b2.33 ii6
+m82 b1 V7 b1.67 vi b2.33 IV
+m83 b1.33 V7 b2.33 I
+m84 b1 I
+m85 b1 IV b1.67 V7 b2 I

--- a/Corpus/HaydnOp20/op20n5-04.txt
+++ b/Corpus/HaydnOp20/op20n5-04.txt
@@ -1,0 +1,183 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in F Minor - No.4: Fuga a due soggetti
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 f: V
+m2 b1 i
+m3 b1 viio
+m4 b1 iv
+m5 b1 iv6
+m6 b1 V6
+m7 b1 i
+m8 b1 i6 b3 i
+m9 b1 V7/V
+m10 b1 V
+m11 b1 i6 b2 ii b3 i
+m12 b1 V65/V
+m13 b1 V7
+m14 b1 i b3 iv6
+m15 b1 V65
+m16 b1 i
+m17 b1 i6
+m18 b1 V43/V b3 V7/V
+m19 b1 V
+m20 b1 i6
+m21 b1 V2
+m22 b3 i6 b4 i
+m23 b1 V65
+m24 b1 V7/iv
+m25 b1 V7/VII
+m26 b1 V7/VI
+m27 b1 VI
+m28 b1 VII
+m29 b1 iv64
+m30 b1 i
+m31 b1 v64
+m32 b1 iio7
+m33 b1 i6 b3 i
+m34 b1 VII6 b3 VII
+m35 b1 viio6/VII b3 viio/VII
+m36 b1 V
+m37 b1 i6 b3 i
+m38 b1 V65/III
+m39 b1 III
+m40 b1 III
+m41 b1 V7/III
+m42 b1 V7/VI
+m43 b1 viio7/iv
+m44 b1 V7/VII
+m45 b1 V65/v
+m46 b1 v
+m47 b1 v6 b3 i
+m48 b1 V/V b3 V65/V
+m49 b1 V b3 V65
+m50 b1 V/iv b3 V65/iv
+m51 b1 V/VII b3 V65/VII
+m52 b1 V/III b3 V65/III
+m53 b1 V/VI
+m54 b1 V65/iv
+m55 b1 iv
+m56 b1 iv6
+m57 b1 V7/iv
+m58 b1 bb: i
+m59 b1 V7/VII
+m60 b1 iv/iv
+m61 b1 V7/VI
+m62 b1 VI b3 iv7
+m63 b1 V65/VI
+m64 b1 VI
+m65 b1 V65/VI
+m66 b1 Gb: I
+m68 b1 V2/V
+m69 b1 Db: I
+m71 b1 V2/V
+m72 b1 Ab: I
+m73 b1 I
+m74 b1 V2/v
+m75 b1 eb: i
+m77 b1 viio7/v
+m78 b1 bb: i
+m80 b1 viio7/v b3 V2/v
+m81 b1 f: i
+m83 b1 V7/v
+m84 b1 c: i b3 VI
+m85 b1 viio
+m86 b1 i
+m87 b1 VI b3 iv
+m88 b1 V7
+m89 b1 i b3 V7/iv
+m90 b1 f: i b3 VI
+m91 b1 V6
+m92 b1 i
+m93 b1 i6 b3 viio65
+m94 b1 viio43
+m95 b1 i6
+m96 b1 iv
+m97 b1 -VII7
+m98 b1 III7
+m99 b1 VI7
+m100 b1 ii
+m101 b1 V7
+m102 b1 i
+m103 b1 V7
+m104 b1 V7 b3 VI
+m105 b1 V7
+m106 b1 i64
+m107 b1 viio7/V
+m108 b1 i64
+m109 b1 V7 b4 i64
+m110 b1 iio6
+m111 b1 viio7
+m112 b1 i
+m113 b1 i6
+m114 b1 V2 b3 i6
+m115 b1 viio64/V
+m116 b1 V
+m117 b1 i
+m118 b1 V65 b3 i
+m119 b1 viio43/V b3 V2/V
+m120 b1 V64 b3 V6
+m121 b1 i6
+m122 b1 iv b3 iio
+m123 b1 V2
+m124 b1 i
+m125 b1 V65
+m126 b1 i b3 i7
+m127 b1 VI b3 iv65
+m128 b1 VII
+m129 b1 III6 b3 V65/VI
+m130 b1 VI
+m131 b1 iv
+m132 b1 V
+m133 b1 i64
+m134 b1 V
+m135 b1 i64
+m136 b1 V b3 i64
+m137 b1 viio43/V
+m138 b1 V
+m139 b1 viio7/V
+m140 b1 viio43
+m141 b1 i64
+m142 b1 None
+m143 b1 V b3 i64
+m144 b1 None
+m145 b1 V
+m146 b1 i
+m147 b1 viio7 b3 V7
+m148 b1 V
+m149 b1 i b4 i7
+m150 b1 VI b3 iv
+m151 b1 IV b4 V7/VII
+m152 b1 viio b2 i b3 V7
+m153 b1 i b3 VI
+m154 b1 viio7 b3 V7
+m155 b1 v
+m156 b1 viio65/V b3 viio7/V
+m157 b1 iv6 b3 iv
+m158 b1 V7 b3 i
+m159 b1 iio65
+m160 b1 i
+m161 b1 V65
+m162 b1 i
+m163 b1 V2
+m164 b1 i6
+m165 b1 iio6 b3 V7
+m166 b1 VI
+m167 b1 viio7
+m168 b1 i
+m169 b1 viio43
+m170 b1 i6
+m171 b1 viio43/V
+m172 b1 V6
+m173 b1 iio
+m174 b1 viio
+m175 b1 viio7
+m176 b1 viio7
+m179 b1 i
+m180 b1 i6 b3 iv
+m181 b1 V7
+m182 b1 i
+m183 b1 V
+m184 b1 i

--- a/Corpus/HaydnOp20/op20n6-01.txt
+++ b/Corpus/HaydnOp20/op20n6-01.txt
@@ -1,0 +1,151 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in A Major - No.1: Allegro di molto e scherzando
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 6/8
+m1 b1 A: I
+m2 b1.67 V b2 I
+m3 b1 V b2 I
+m4 b1 V7 b2 I
+m5 b1 I
+m6 b1.67 V b2 I
+m7 b1 IV
+m8 b1 V7 b2 I
+m9 b1 V7 b2 I
+m10 b1 V7 b2 I
+m12 b1.67 V b2 I
+m13 b1 V
+m14 b1 I
+m15 b1 V7/vi
+m16 b1 vi
+m18 b2 V/V
+m19 b1 V7/V
+m22 b1 E: I b2 ii
+m23 b1 viio b2 I
+m24 b1 vi b2 V7 b2.67 I
+m25 b1 IV b2 V
+m26 b1 I b1.67 V7 b2 I b2.67 V7
+m27 b1 I b1.67 V7 b2 I b2.33 V b2.67 I
+m28 b1 V7 b1.33 I b1.67 V7 b2 I b2.33 V7 b2.67 I
+m29 b1 V7
+m31 b1 i
+m32 b1 D: I7 b2 I
+m33 b1 IV b2 V7
+m34 b1 I
+m35 b1 I b2 V7/IV
+m36 b1 IV
+m37 b1 ii b2 V7/VI
+m38 b1 E: V
+m39 b1.33 viio7/V b1.67 V b2.33 viio7/V b2.67 V
+m40 b1.33 viio7/V b1.67 V b2.33 viio7/V b2.67 V
+m42 b1 I
+m43 b1 I b1.33 V7 b1.67 I b2 IV b2.67 ii
+m44 b1 I64 b1.67 V7 b2 I
+m45 b1 i
+m46 b1.33 viio7/V b2 V
+m47 b1.67 i64 b2 V b2.67 V7
+m48 b1.67 i64 b2 V b2.67 viio7/V
+m49 b1 V b1.67 i64 b2.67 viio7/V
+m50 b1 V b1.67 viio7/V
+m51 b1.67 I
+m53 b1 V b2 I b2.33 V7 b2.67 I
+m54 b1 IV b2 I64 b2.67 V
+m55 b1 I
+m56 b1 vi b2 V
+m57 b1 I b2 V7/vi
+m58 b1 vi b1.67 ii b2.67 V7
+m59 b1 I b2.67 V7
+m60 b1 I b2.67 V7
+m61 b1 I b2 IV
+m62 b1 I b2 IV
+m63 b1 I b2 V7
+m64 b1 V7/IV
+m65 b1 V7/IV
+m66 b1 b: V7 b2 i
+m67 b1 V7 b2 i
+m68 b1 Ger7
+m70 b1 VI b2 V7
+m71 b1 V7/II
+m72 b1 II b2 II7
+m73 b1 V7
+m74 b1 iv
+m75 b1 iio
+m76 b1 V7
+m77 b1 It b2 Ger7
+m79 b1 VI
+m80 b1 V7/vii
+m81 b1 vii
+m82 b1 V7
+m83 b1 i
+m84 b1 iv
+m85 b1 V7/III
+m86 b1 III
+m87 b1 iv
+m88 b1 ii
+m89 b1 V7
+m90 b1 ii b2 V7
+m91 b1 ii b2 V7
+m92 b1 ii b2 V7
+m93 b1 ii b2 V7
+m94 b1 V b2 i
+m95 b1 V b2 i
+m96 b1 V
+m97 b1 viio7
+m100 b1 i b2 iio
+m101 b1 V7 b2 VI
+m102 b1 i b2 iio
+m103 b1 V b2 i
+m104 b2 V
+m105 b1 i b2 V
+m106 b1 A: vi b2 V7
+m107 b1 I b2 V
+m109 b1 I
+m110 b1.67 V b2 I
+m111 b1 V b2 I
+m112 b1 V7 b2 I
+m113 b1 a: i
+m114 b1.67 V b2 i
+m115 b1 iv b2 VII
+m116 b1 III b2 VI
+m117 b1 iio b2 V
+m118 b1 i b2 VI b2.67 It
+m119 b1 V
+m121 b1 V7
+m122 b1 I b2 ii
+m123 b1 V7 b2 i
+m124 b1 vi b2 V7
+m125 b1 IV b2 V
+m126 b1 I b1.67 V7 b2 I b2.67 V7
+m127 b1 I b1.67 V7 b2 I b2.33 V7 b2.67 I
+m128 b1 V7 b1.33 I b1.67 V7 b2 I b2.33 V7 b2.67 I
+m129 b1 V7
+m131 b1 i
+m132 b1 G: I7 b2 I
+m133 b1 IV b2 V7
+m134 b1 I
+m135 b2 V7/IV
+m136 b1 IV
+m137 b1 i b2 V7/V
+m138 b1 V
+m139 b1 viio7/V b1.67 V b2 viio7 b2.67 V
+m140 b1 viio7 b1.67 V b2 viio7 b2.67 V
+m142 b1 I
+m143 b1 I b1.67 V7 b2 IV b2.67 ii
+m144 b1 I64 b1.67 V7 b2 I
+m145 b1 i
+m147 b1 i64 b2 V
+m148 b1 i64 b2 V
+m149 b1 i64
+m153 b1 V b2 I
+m154 b1 IV b2 I b2.67 V7
+m155 b1 I
+m156 b1 vi b2 V
+m157 b1 I b2 V7/vi
+m158 b1 vi b2 ii b2.67 V7
+m159 b1 I b2.67 V7
+m160 b1 I b2.67 V7
+m161 b1 I b2 IV
+m162 b1 I b2 IV
+m163 b1 I
+m166 b1 I

--- a/Corpus/HaydnOp20/op20n6-02.txt
+++ b/Corpus/HaydnOp20/op20n6-02.txt
@@ -1,0 +1,82 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in A Major - No.2: Adagio
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 E: I b4 V7
+m2 b1 I b4 V7
+m3 b1 I
+m4 b1 IV b2 I
+m5 b1 ii b4 V7
+m6 b1 I b4 I6
+m7 b1 ii6 b4 V7
+m8 b1 I b2 IV
+m9 b1 I b4 V7
+m10 b1 I b2 I6 b4 V7
+m11 b1 I b3 V7/IV
+m12 b1 IV64 b3 viio
+m13 b1 I
+m14 b1 I64 b2 V
+m15 b1 V6 b4 V+65
+m16 b1 I b4 V65/ii
+m17 b1 V/V b3 viio7/ii b4 viio/IV
+m18 b1 V/V b3 viio7/ii b4 viio/IV
+m19 b1 V/V b3 V7/V
+m21 b1 V6 b3 V65
+m22 b1 I
+m23 b1 I64
+m24 b1 V64 b3 V7/V
+m25 b1 V b3 I b4 V7/V
+m26 b1 V b3 I b4 V7/V
+m27 b1 viio/V b3 V
+m28 b1 I b4 V7
+m29 b1 I b4 V7
+m30 b1 I
+m31 b1 IV b2 I
+m32 b1 ii b4 V7
+m33 b1 I b2 iii64 b4 I6
+m34 b1 ii6 b4 V7
+m35 b1 viio b2 I
+m36 b1 I b4 V7
+m37 b1 I b2 I6 b4 V7
+m38 b1 I b3 V7/IV
+m39 b1 IV64 b3 viio
+m40 b1 I
+m41 b1 I64 b2 V
+m42 b1 V6
+m43 b1 I b2 I+ b4 vi6
+m44 b1 V/V b3 viio7/ii b4 viio/IV
+m45 b1 V/V b3 viio7/ii b4 viio/IV
+m46 b1 V/V b2 V7/V
+m48 b1 V6 b3 V65
+m49 b1 I
+m50 b1 I
+m51 b1 V64 b3 V7/V
+m52 b1 V
+m53 b1 V b2 V6
+m54 b1 v
+m55 b1 V2/ii
+m56 b1 ii6
+m57 b1 V7/vii
+m58 b1 vi64
+m59 b1 V/vi
+m60 b1 vi6
+m61 b1 ii
+m62 b1 I
+m63 b1 IV
+m64 b1 V b3 V2
+m65 b1 I6
+m66 b1 IV b4 II+6
+m67 b1 V
+m68 b1 vi
+m69 b1 V b3 viio7/V
+m70 b1 V b3 viio7/V
+m71 b1 V b3 V7
+m73 b1 i
+m74 b1 Ger7
+m75 b1 I64
+m76 b1 I64 b3 V7
+m77 b1 I b3 IV b4 V7
+m78 b1 I b3 IV b4 V7
+m79 b1 viio b3 I

--- a/Corpus/HaydnOp20/op20n6-03.txt
+++ b/Corpus/HaydnOp20/op20n6-03.txt
@@ -1,0 +1,42 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in A Major - No.3: Menuetto
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 3/4
+m1 b1 A: I
+m2 b1 V43 b2 I
+m3 b1 iii6 b3 V7
+m4 b1 I
+m5 b1 IV b3 I64
+m6 b1 ii6 b2 V b3 I6
+m7 b1 V
+m10 b1 I
+m11 b1 V7
+m13 b1 I
+m14 b1 IV
+m15 b1 V b2 I64 b3 V
+m16 b1 I
+m17 b1 I
+m18 b1 V43 b2 I
+m19 b1 I64 b3 V7
+m20 b1 I
+m23 b1 iv6 b2 V b3 iv
+m24 b1 I b3 I+6
+m25 b1 IV b3 I64
+m26 b1 IV6 b3 viio6/V
+m27 b1 V b2 V7 b3 I64
+m28 b1 V
+m29 b1 V b3 I64
+m30 b1 V7 b3 I64
+m31 b1 V b3 I64
+m32 b1 V7
+m33 b1 I
+m35 b1 iv6 b2 V b3 iv
+m36 b1 I
+m37 b1 I b2 viio b3 vi
+m38 b1 V
+m39 b1 V7
+m40 b1 vii b3 I
+m41 b1 ii6 b2 I64 b3 V
+m42 b1 I

--- a/Corpus/HaydnOp20/op20n6-04.txt
+++ b/Corpus/HaydnOp20/op20n6-04.txt
@@ -1,0 +1,98 @@
+Composer: Haydn, Franz Joseph
+Title: String Quartet in A Major - No.4: Fuga a tre soggetti: Allegro
+Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
+Proofreader: Automated translation using music21 and Mark Gotham's code.
+
+Time Signature: 4/4
+m1 b1 A: I b4 I
+m2 b4 vi
+m3 b4 IV
+m4 b3 V65
+m5 b1 I b4 V
+m6 b4 iii
+m7 b2 V/V b4 I
+m8 b2 V6 b4 V/V
+m9 b1 V b3 I6
+m10 b1 iii
+m11 b1 V6
+m12 b1 iii6 b2 I64 b3 ii
+m13 b1 I
+m17 b1 V6 b3 I b4 I
+m18 b4 vi6
+m19 b4 ii65
+m20 b1 I6 b3 ii7 b4 V64
+m21 b1 I
+m22 b1 I6 b2 IV b4 iii
+m23 b1 V6/ii b2 ii b4 I
+m24 b1 IV65 b2 viio b4 vi
+m25 b1 Ger7/VI b3 V/VI
+m26 b1 VI6
+m27 b1 V6
+m28 b1 IV6 b3 v7
+m29 b1 IV b2 ii6 b3 iii
+m30 b1 ii b2 V7 b3 I
+m31 b1 IV b3 v6
+m32 b1 IV6 b2 viio b3 I64
+m33 b1 ii6 b2 v b3 I6
+m34 b1 None b2 iio/ii b3 None b4 VI6/ii
+m35 b1 None b2 V6/ii b3 ii
+m36 b1 V6/ii b2 V7/ii b3 ii b4.5 V7/V
+m37 b1 V6 b3 I
+m38 b1 V6 b2 V b3 ii
+m39 b1 vi6 b2 vi b3 iii
+m40 b1 V/iii b3 c#: i6 b4 i
+m41 b1 iv b3 iio
+m42 b1 III b3 i
+m43 b1 iio b3 V6
+m44 b1 i6 b2 i b4 V6
+m45 b1 i b2 VI6 b3 V6
+m46 b1 VI b2 iv6 b3 v
+m47 b1 f#: i
+m48 b1 i6 b3 iio7
+m49 b1 i b2 iv64 b4 III
+m50 b1 VI b2 iio64 b4 V7/iv
+m51 b1 b: i b3 V6
+m52 b1 i b2 V/IV b3 E: I6
+m53 b1 ii b3 I b4.5 vi6
+m54 b1 viio b2 V43 b3 vi
+m55 b1 V b3 IV
+m56 b1 V/vi b2 vi64
+m57 b1 vi6 b2 vi
+m58 b1 ii6 b2 ii
+m59 b1 V6 b2 V
+m60 b1 I6 b2 V/IV
+m61 b1 A: I b2 I
+m62 b1 V6 b3 vi b4 ii7
+m63 b1 V b3 IV b4 viio65
+m64 b1 I6 b3 V7
+m65 b1 I
+m66 b1 vi b3 V b4 I64
+m67 b1 IV b2 viio7 b3 I6 b4 vi6
+m68 b1 ii b2 V65 b3 I b4.5 viio7/V
+m69 b1 V b3 I
+m70 b1 ii b3 I64 b4 IV6
+m71 b1 V b3 vi6 b4 ii6
+m72 b1 V7 b3 viio64/V
+m73 b1 V b4 ii
+m74 b1 V7 b2 I64 b4 V
+m75 b1 I64 b4 V
+m76 b1 I6 b2 I
+m77 b1 IV6 b2 IV b4 ii
+m78 b1 V6 b2 V b3 I b4 vi
+m79 b1 ii b3 V
+m80 b1 I
+m81 b1 V b3 vi b4 ii7
+m82 b1 V b2.5 iii b3 IV b4 iio7
+m83 b1 iii b2.5 I b3 IV64 b4 I6
+m84 b1 V
+m85 b1 V
+m86 b1 vi
+m87 b1 V b3 I
+m88 b1 V b3 I6
+m89 b1 ii b2 V b4 IV64
+m90 b1 V6 b2 iii b4 ii43
+m91 b1 V7 b2 I b3 ii65
+m92 b1 I b4 vi6
+m93 b1 viio64 b3 I
+m94 b1 V2 b3 I b4 V
+m95 b1 I


### PR DESCRIPTION
An initial PR.

Things that I noticed so far.

- [ ] There are some annotations showing `None` instead of a valid RNA entry. These are surely things that went unrecognized by my `**harm` parser in music21.
- [ ] The way I understand your `romanWrite.py` code, it either takes a stream with a single part, or the first part of a multi-part stream. Oftentimes, the annotations are distributed across different parts (side effect of using lyrics where you are forced to link an annotation with a specific note and the bass is a held note, for example), meaning, there may be annotations lost in the process of using `romanWrite.py`. If the script takes into account annotations coming from different parts, then this is not a problem. 