### PR TITLE
Correcting errors in BPS-FH files

### DIFF
--- a/Corpus/BPS-FH/01-i.txt
+++ b/Corpus/BPS-FH/01-i.txt
@@ -127,6 +127,6 @@ m146 b1 V65/iv
 m147 b1 iv
 m148 b1 V65/III
 m149 b1 III b2.5 VI65
-m150 b1 ii b1 V65 b2 i b2.5 VI
+m150 b1 ii b2 V65 b3 i b4 VI
 m151 b1 ii65 b2 V7
 m152 b1 i

--- a/Corpus/BPS-FH/12-i.txt
+++ b/Corpus/BPS-FH/12-i.txt
@@ -28,7 +28,7 @@ m22 b1 vi6 b1.5 V6/vi b2 vi
 m23 b1 E-: I64 b2 vii7/vi
 m24 b1 vi b1.5 IV b2 V6/V
 m25 b1 I64 b2 V7
-m26 b1 I b1.5 A-: vii6/V b1.5 I b2 V65
+m26 b1 I
 m28 b1 V43
 m29 b1 I6 b2 V6
 m30 b1 I b1.5 V


### PR DESCRIPTION
Fixes one of the conflicting files in #7.

The offending line is
```
m150 b1 ii b1 V65 b2 i b2.5 VI
```

Two entries for `b1` crash the music21 RomanText  parser.

This is the music it refers to
![image](https://user-images.githubusercontent.com/7258463/100491984-31c4c800-30f6-11eb-903a-4b2a1d3ea83f.png)

The harmony annotations are correct, the beats need to be corrected.

Corrected beats in this PR
