### PR TITLE
Adding two syntax corrections to added intervals

### DIFF
--- a/Corpus/OpenScore-LiederCorpus/Holmès,_Augusta_Mary_Anne/Les_Heures/4_L’Heure_d’Azur/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Holmès,_Augusta_Mary_Anne/Les_Heures/4_L’Heure_d’Azur/analysis.txt
@@ -10,7 +10,7 @@ m1 b1 B: I b2 vi6 b3.5 I6
 m2 b1 viio6 b2 V9
 m3 b1 I b2 vi6 b3.5 I6
 m4 = m2
-m5 b1 V65add9
+m5 b1 V65[add9]
 m6 b1 G: V9 b2 V7
 m7 b1 c#: iio7 b2 V64 b3 viio6
 m8 b1 V64 b2 ii b3 V43

--- a/Corpus/Variations_and_Grounds/Bach,_Johann_Sebastian/B_Minor_mass,_BWV232/Crucifixus/analysis.txt
+++ b/Corpus/Variations_and_Grounds/Bach,_Johann_Sebastian/B_Minor_mass,_BWV232/Crucifixus/analysis.txt
@@ -71,7 +71,7 @@ Note: cf m.7
 m39 b1 viio7/iv b2 viio42 b3 iv6
 m39var1 b1 #vi75b4 b2 viio42 b3 iv6
 m40 b1 a: iiø7
-m40var1 b1 a: iiø7 b2 iiø7[add9[] b3 iiø7
+m40var1 b1 a: iiø7 b2 iiø7[add9] b3 iiø7
 
 Form: Iteration 11
 m41 b1 V9 b3 V7


### PR DESCRIPTION
I noticed that having an `addX` annotation without square brackets produces issues within music21. For example, it won't make any changes to the attribute `.addedSteps`, whereas `[addX]` would add the interval to `.addedSteps`.

This PR changes one instance where `addX` is used without square brackets, and another instance with a weird syntax.

