### PR TITLE
Adding an explicit [no3] or [no5] to seventh 73 and 75 degrees

### DIFF
--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/10/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/10/analysis.txt
@@ -7,7 +7,7 @@ Time signature: 4/4
 
 m1 b1 e: i
 m2 b1 iiø42
-m3 b1 viio7 b3 V75
+m3 b1 viio7 b3 V7[no3]
 m4 b1 i
 m5 b1 iiø42 b3 v65
 m6 b1 G: vi42 b3 ii65
@@ -42,7 +42,7 @@ m31 b1 viio65/v b3 i64
 m32 b1 viio7/v b3 v
 m33 b1 i65 b3 vio63
 m34 b1 viio65/ii b3 e: V7
-m35 b1 III6 b3 V75
+m35 b1 III6 b3 V7[no3]
 m36 b1 i64 b3 V7
 m37 b1 viø42 b3 V7
 m38 b1 III+43 b3 V9

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/12/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/12/analysis.txt
@@ -8,7 +8,7 @@ Time signature: 4/4
 m1 b1 f: i b2 viio64 b3 i
 m2 b1 iiø42 b2 viio65 b3 i b4 viio63
 m3 b1 i6 b2 iio6 b3 V b4 iv6
-m4 b1 viio7 b2 V73 b3 bb: V7 b4 iv6b5
+m4 b1 viio7 b2 V7[no5] b3 bb: V7 b4 iv6b5
 m5 b1 viio7 b2 V7 b3 ib3 b4 Ab: viio6
 m6 b1 viio b1.5 ii b2 v5 b3 I b4 viio6
 m7 b1 iii b2 ii6 b3 V b4 IV6

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/13/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/13/analysis.txt
@@ -15,7 +15,7 @@ m7 b1 I b3 IV6 b4 iii6
 m8 b1 ii6 b2 d#: viio6 b3 bVI6 b4 v6
 m9 b1 iv6 b2 III6 b3 bII6 b4 i6
 m10 b1 iiø7[no5] b2 iv4 b3 viio7 b4 v7
-m11 b1 i b2 i6 b3 iiø65 b4 V73
+m11 b1 i b2 i6 b3 iiø65 b4 V7[no5]
 m12 b1 i b3 a#: iiø7
 m13 b1 viio65
 m13var1 b1 viio65 b4 III

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/19/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/19/analysis.txt
@@ -15,9 +15,9 @@ m7 b1 I b2 vi b3 viio b4 V
 m8 b1 vi b2 A: viio b3 I b4 vi
 m9 b1 iii b2 v b3 vi6 b4 ii7
 m10 b1 V65 b2 V7/IV b3 IV b3.5 ii7 b4 V7
-m11 b1 vi6 b1.5 f#: V64 b2 VI6 b3 ii7 b4 V73
+m11 b1 vi6 b1.5 f#: V64 b2 VI6 b3 ii7 b4 V7[no5]
 m12 b1 i b2 VI6 b3 V6 b4 v6
-m13 b1 viø7 b2 ii7 b3 V73 b4 i
+m13 b1 viø7 b2 ii7 b3 V7[no5] b4 i
 m14 b1 i b2 viio b3 i6
 m15 b1 B: vi b2.5 viiø43 b3 I b4 E: V7
 m16 b1 I6 b2.5 viio6 b3 I b4 A: I

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/23/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/23/analysis.txt
@@ -15,8 +15,8 @@ m7 b1 g#: VI7 b2 viio42 b3 V7 b4 i64
 m8 b1 i64 b2 viio64 b3 III+7 b4 i
 m9 b1 iiø42 b2 viio b3 viio42 b4 iv
 m10 b1 i64 b2 V7 b3 i
-m11 b1 f#: V73 b3 i
-m11var1 b1 f#: V73 b2 viio65 b3 i
+m11 b1 f#: V7[no5] b3 i
+m11var1 b1 f#: V7[no5] b2 viio65 b3 i
 m12 b1 E: V7 b3 I b4 B: V43
 m13 b1 V b2 V7/IV b3 IV7 b4 ii
 m14 b1 V b2 IV b3 ii7 b4 V7

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/24/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/24/analysis.txt
@@ -27,9 +27,9 @@ m19 b1 i6 b2 V b3 i
 m20 b1 D: V43 b3 I b4 V
 m21 b1 I b3 vi b4 f#: viio65
 m22 b1 viio7 b1.5 i b3 iv7 b4 bII6
-m23 b1 V73 b1.5 i b3 iio6
+m23 b1 V7[no5] b1.5 i b3 iio6
 m24 b1 V b3 i
-m25 b1 iio b3 V73 b4 i
+m25 b1 iio b3 V7[no5] b4 i
 m26 b1 iio6 b3 V42 b4 i6
 m26var1 b1 iio6 b3 V432 b4 i6
 m27 b1 i64 b2 V b3 i[no3] b4 e: viio7
@@ -55,5 +55,5 @@ m43 b1 iv b2 i65[#7] b3 iiø7 b4.5 ii65/iv
 m43var1 b1 iv b2 bvi#54 b3 iiø7 b4.5 ii65/iv
 m44 b1 IV6 b2 V64/iv b3 iv b4.5 viio65
 m45 b1 i b2.5 viio7/v b3.5 viio65/iv b4 iv
-m46 b1 i64 b2 V b3 V73/iv b3.5 viio42 b4.5 i[no3]
+m46 b1 i64 b2 V b3 V7[no5]/iv b3.5 viio42 b4.5 i[no3]
 m47 b1 iv64 b2 viio65 b3 I

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/4/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/4/analysis.txt
@@ -26,7 +26,7 @@ m17var1 b1 c#: V7 b2 V7 b2.5 ii54 b2.67 viio
 m18 b1 i
 m19 b1 f#: viio7
 m20 b1 i
-m21 b1 A: V6 b1.5 I b1.67 V73/V b2 V
+m21 b1 A: V6 b1.5 I b1.67 V7[no5]/V b2 V
 m22 b1 c#: i b2 viio65
 m23 b1 V7 b2 i64
 m24 b1 iv b2 bII6

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/6/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/6/analysis.txt
@@ -16,7 +16,7 @@ m8 b1 i b2.5 a: bvii6b42 b3 V7 b3.5 viio43 b4 III+7 b4.5 viio63
 m9 b1 i b2 IV7 b2.5 III+6 b3 bVI b3.5 i6 b4 iiø65 b4.5 V
 m10 b1 i b2 F: IV42 b2.5 viio6 b3 I b4 d: IV42 b4.5 viio63
 m11 b1 i b2 Bb: IV42 b2.5 viio6 b3 I b3.5 I b4 g: IV42 b4.5 viio63
-m12 b1 i b2 bVI6 b2.5 i6 b3 d: V73 b3.5 viio43 b4 III+7 b4.5 viio63
+m12 b1 i b2 bVI6 b2.5 i6 b3 d: V7[no5] b3.5 viio43 b4 III+7 b4.5 viio63
 m13 b1 i b2 IV7 b2.5 i4#3 b3 bVI b3.5 i6 b4 iv7 b4.5 V
 m14 b1 viio42 b1.5 i6 b2 iiø65 b2.5 V65/VI b3 bVI b3.5 iii6/VI b4 iiø65 b4.5 V
 m15 b1 g: V9 b3 i64

--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/7/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/7/analysis.txt
@@ -38,7 +38,7 @@ m30 b1 I7 b2 I7 b3 V/V b4 V
 m31 b1 I43 b2 vi6 b3 V42/V b4 V6
 m32 b1 iii7 b2 I6 b3 vi43 b4 V42/V
 m33 b1 V/V b3 g: V65 b4 i64
-m34 b1 iv9 b2 viio43 b3 V73 b3.5 i64 b4 V7
+m34 b1 iv9 b2 viio43 b3 V7[no5] b3.5 i64 b4 V7
 m35 b1 bVI6 b3 f: IV
 m36 b1 viio7 b2 i b3 iv7
 m37 b1 V9 b3 bVI b4 iv65
@@ -57,7 +57,7 @@ m49 b1 V7 b3 Ib7 b4 Eb: I
 m50 b1 IV64 b2 viio b3 I6
 m51 b1 V65/ii b2 V42/V b3 c: viio65
 m52 b1 viio65 b3 i64
-m53 b1 bVI b2 iv65 b3 V73 b4 i
+m53 b1 bVI b2 iv65 b3 V7[no5] b4 i
 m54 b1 bVI6 b2 iio6 b3 V42 b4 i6
 m55 b1 bVI b2 f: i6 b3 V7
 m56 b1 i b2 Ab: IV6 b3 viio42 b4 iii


### PR DESCRIPTION
Not 100% sure about this one.

If I understand correctly, the idea behind a `V73` or `V75` annotation is to indicate that either the `5` or `3` have been omitted.

It would be more informative to have that information being explicit (and selfishly easier to parse on my personal use case). That is:

1) If we assume that
`"V75" == "V7[no3]"`
`"V73" == "V7[no5]"`

The latter are better representations because they add information to the `.omittedSteps` attribute of the RomanNumeral. They are also easier to ignore, say, if one wanted to forget about omitted steps and keep only the "full" figure.

If the assumptions are correct, this PR corrects all instances I could find of this kind in the corpus.