### PR TITLE
Adding a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Code/__pycache__/


### PR DESCRIPTION
Maybe there are other temporary files that can be conveniently ignored in version control (e.g., MuseScore temporary files, other python temporary files, etc.). 

However, one that is particularly present at the time is the `__pycache__` generated after running code within the `Code/` folder. This `__pycache__` should not be committed to version history and shouldn't give the impression of changes to the repo when it is created automatically.

This commit pushes a gitignore file to ignore the `__pycache__`.