### PR TITLE
A better translation of the **harm annotations in Haydn Op.20

### DIFF
--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/1/analysis.txt
@@ -1,15 +1,16 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - No.1: Allegro moderato
+Title: String Quartet in E-flat Major - 1: Allegro moderato
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
+
 m1 Eb: I
 m4 b2 V7 b3 I
 m6 b4 V43/V
-m7 V6
+m7 V6 b3 V
 m8 V6
-m9 V65/V
+m9 V65/V b3 V6
 m10 b3 V7
 m11 I b3 I6
 m12 I
@@ -24,11 +25,11 @@ m21 viio65/vi b2 vi b3 V64 b4.5 V6
 m22 I b3 V64 b4 V/V
 m24 b3 V6
 m26 V65 b3 I
-m27 b3 viio7/V/V
+m27 b3 viio7/V/V b4 V7/V
 m28 V
 m29 b3 I b4 vi
 m31 V65/V b2 V b3 vi6 b4 V64 b4.5 V7/V
-m32 V
+m32 V b3 V/V
 m33 V
 m34 V
 m35 V/V
@@ -39,7 +40,7 @@ m41 V/vi b2 III
 m44 I
 m47 b3 ii
 m48 b3 V
-m50 V6/ii
+m50 V6/ii b3 ii
 m51 b3 V65/ii
 m52 b3 ii
 m53 b3 V6
@@ -49,7 +50,7 @@ m56 b3 vi
 m57 b3 viio43/vi
 m58 vi b3 viio43/vi
 m59 vi b3 N6/vi
-m60 b3 viio7/V/vi
+m60 b3 viio7/V/vi b4 V7/vi
 m61 vi
 m62 b3 iio6/vi b4 V/vi
 m63 vi
@@ -77,13 +78,13 @@ m91 b3 viio65/ii b4 ii6
 m92 I64 b3 ii65
 m93 I64 b3 V7
 m94 I64 b3 V7
-m95 I b2 V65/IV b3 IV
+m95 I b2 V65/IV b3 IV b4 ii
 m96 b4.5 V7
 m97 I
 m98 b2 V7/IV b3 IV6 b4 ii
 m100 V65 b2 I b3 ii6 b4 I64 b4.5 V
-m101 I
-m102 V
+m101 I b3 ii43
+m102 V b3 I6 b4 IV b4.5 V
 m103 I b3 V6 b4 ii43
 m104 V b2 ii65 b3 I6 b4.5 V
 m105 I b4 IV64 b4.5 viio

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/1/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - 1: Allegro moderato
+Title: String Quartet in E-flat Major - No.1: Allegro moderato
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/2/analysis.txt
@@ -1,9 +1,11 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - No.2: Menuetto: un poco allegretto
+Title: String Quartet in E-flat Major - 2: Menuetto: un poco allegretto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
+
+m0 b3 Eb: I
 m1 Eb: I
 m2 V43
 m3 I
@@ -22,11 +24,11 @@ m15 v b3 viio7/V/v
 m16 V/v b3 Bb: I6
 m17 I6
 m18 ii6
-m19 I64 b3 None
+m19 I64
 m20 I
-m21 V43/IV
+m21 V43/IV b3 IV6
 m22 I
-m23 V43/IV
+m23 V43/IV b3 IV6
 m24 I
 m25 Eb: I
 m26 V43
@@ -48,8 +50,8 @@ m42 I
 m43 ii6 b3 V7
 m44 I
 m45 IV
-m46 None b3 viio6/IV
-m47 None b2 IV6 b3 viio/IV/IV
+m46 b3 viio6/IV
+m47 b2 IV6 b3 viio/IV/IV
 m48 IV/IV
 m49 I
 m50 IV6/IV

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/2/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - 2: Menuetto: un poco allegretto
+Title: String Quartet in E-flat Major - No.2: Menuetto: un poco allegretto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/3/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - 3: Affettuoso e sostenuto
+Title: String Quartet in E-flat Major - No.3: Affettuoso e sostenuto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/3/analysis.txt
@@ -1,16 +1,17 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - No.3: Affettuoso e sostenuto
+Title: String Quartet in E-flat Major - 3: Affettuoso e sostenuto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/8
+
 m1 Ab: I
 m2 IV64
 m4 I6 b2 V65 b3 I
 m5 ii6 b2 I64 b3 V7
-m6 I
+m6 I b2 IV64
 m8 I
-m9 IV b3 V43
+m9 IV b2 I6 b3 V43
 m10 I b2 IV6
 m11 I6 b2 V65 b3 I
 m12 ii6 b3 viio/V
@@ -20,23 +21,23 @@ m15 vi b2 V b3 V65/V
 m16 V b2 vi b3 V6
 m17 vi6 b3 viio7/V/V
 m18 V/V b2 viio/V/V b3 V6/V
-m19 iii7
+m19 iii7 b2 vi b3 vi2
 m20 viio7/V b2 V b3 V2
 m21 I7 b2 viio/V/V b3 I6
 m22 V7 b2 viio7/iii b3 iii
 m23 vi b3 V7
-m24 V6
+m24 V6 b3 ii65
 m25 V/vi b2 vi b3 vi2
 m26 V65/V b2 v b3 ii6
 m27 Ger7/V
 m28 V64 b2 V/V
-m29 iii2
+m29 iii2 b2 vi6
 m30 V2/V
 m32 V b2 V65
 m33 I6 b2 V64 b3 V/V
-m34 V
+m34 V b2 I64 b3 V
 m35 V b3 V7/V
-m36 V b2 I64
+m36 V b2 I64 b3 V
 m37 V b3 V7/V
 m38 V
 m39 Eb: I
@@ -44,27 +45,27 @@ m40 IV64 b3 V7
 m41 I b2 IV
 m42 I6 b2 V65 b3 I
 m43 ii6 b2 I64 b3 V7
-m44 I
+m44 I b2 i
 m45 vi b2 v b3 viio7/v
 m46 bb: vi b2 ii b3 i6
-m47 iio65 b3 V65
+m47 iio65 b2 V b3 V65
 m48 VI
 m49 V6/III b3 V65/III
 m50 Db: I b2 ii b3 I6
 m51 ii6 b2 I64 b3 V7
-m52 I
-m53 IV b3 Ger7/V
+m52 I b2 ii7 b3 I6
+m53 IV b2 I6 b3 Ger7/V
 m54 V/V
-m55 V b3 Ger7/vi
+m55 V b2 V6/V b3 Ger7/vi
 m56 V/vi
 m57 bb: i
-m58 iio65 b3 iio7/iv
-m59 V65/iv b3 iio2/III
-m60 V65/III
-m61 III b3 V/III
-m62 III
+m58 iio65 b2 V b3 iio7/iv
+m59 V65/iv b2 iv b3 iio2/III
+m60 V65/III b2 III b3 V6/III
+m61 III b2 V/V/III b3 V/III
+m62 III b2 i6 b3 III
 m63 iv b2 v b3 VI
-m64 V/III b3 V7/IV
+m64 V/III b2 v b3 V7/IV
 m65 IV b3 viio/IV
 m66 IV b3 viio/IV
 m67 IV b3 i
@@ -73,26 +74,26 @@ m69 III b3 vi
 m70 III64 b3 III
 m71 V6/III
 m72 i b2 V64/III b3 iv7
-m73 V2 b3 None
-m74 V2/V/III
+m73 V2 b2 i6
+m74 V2/V/III b2 V/III
 m75 III b3 viio7/IV
 m76 V/VII b2 viio6/V/VII b3 V6/V/VII
-m77 Ab: vi65
+m77 Ab: vi65 b2 ii6 b3 ii2
 m78 V65 b2 I b3 I2
 m79 vi7 b2 viio7 b3 ii43
 m80 V7 b2 viio7/vi b3 vi
 m81 IV b2 I64 b3 V7
-m82 I6
+m82 I6 b2 I b3 v6
 m83 V7/ii b2 ii b3 ii2
 m84 viio b2 i b3 V64
 m85 Ger7
 m86 V7
-m87 vi7
+m87 vi7 b2 ii6
 m88 V2
 m90 I b2 V65/IV
-m91 None b1.5 IV b2 I64 b3 V7
-m92 I
-m93 b3 V7
+m91 b1.5 IV b2 I64 b3 V7
+m92 I b2 IV64 b3 I
+m93 b2 I b3 V7
 m94 I b2 IV64 b3 I
-m95 b3 V7
+m95 b2 I b3 V7
 m96 I

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/4/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - 4: Finale: Presto
+Title: String Quartet in E-flat Major - No.4: Finale: Presto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/4/analysis.txt
@@ -1,13 +1,14 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in E-flat Major - No.4: Finale: Presto
+Title: String Quartet in E-flat Major - 4: Finale: Presto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 2/4
+
 m0 b2.5 Eb: I
-m2 V65/V
+m2 V65/V b2 V7
 m3 I
-m5 IV
+m5 IV b2 V7
 m6 I
 m8 V6 b2.5 V65
 m9 I
@@ -16,10 +17,10 @@ m12 vi b2 IV6
 m13 iii6
 m14 IV b2 ii6
 m15 I6
-m16 viio6
-m17 ii6
+m16 viio6 b2 I
+m17 ii6 b2 V65/V
 m18 V
-m19 viio6/V
+m19 viio6/V b2 V7/V
 m20 V
 m21 viio65/ii
 m22 viio65/ii
@@ -29,16 +30,16 @@ m25 V65/ii
 m26 V65/ii
 m27 V7/V
 m28 V64
-m29 V7/V
-m30 V/V
+m29 V7/V b2 V64
+m30 V/V b2 V64
 m31 viio/V/V
 m32 V/V
 m33 b2.5 Bb: I
 m35 b2.5 I
-m38 V65/V
-m39 V43/V
-m40 V65/V
-m41 V43/V
+m38 V65/V b2 V
+m39 V43/V b2 V
+m40 V65/V b2 V
+m41 V43/V b2 V65/V
 m42 I64 b2.75 V
 m43 I64 b2.75 V
 m44 I64
@@ -51,7 +52,7 @@ m51 IV64 b2.5 viio
 m52 I b2.5 I
 m53 IV64 b2.5 V7
 m54 I
-m57 V65
+m57 V65 b2 V/IV
 m58 IV
 m59 i
 m60 f: V7
@@ -68,11 +69,11 @@ m70 c: V7/VI
 m71 VI
 m72 ii b2.5 viio6/V
 m73 V
-m74 i64
+m74 i64 b2 viio/V
 m75 V
-m76 V7
-m77 V
-m78 V
+m76 V7 b2 i64
+m77 V b2 i64
+m78 V b2 viio/V
 m79 V
 m80 viio43
 m81 i6
@@ -100,9 +101,10 @@ m102 III64
 m103 V/III
 m104 III64
 m105 V/III
-m108 Eb: V65/V
+m106 b2.5 Eb: I
+m108 V65/V b2 V7
 m109 I
-m111 IV
+m111 IV b2 V7
 m112 I
 m114 V6 b2.5 V65
 m115 I
@@ -111,8 +113,8 @@ m118 vi b2 IV6
 m119 iii6
 m120 IV b2 ii6
 m121 I6
-m122 viio6
-m123 ii6
+m122 viio6 b2 I
+m123 ii6 b2 V65/V
 m124 V b2.5 V7
 m125 I
 m126 viio65/V
@@ -123,17 +125,17 @@ m130 V6/V
 m131 V7/V
 m132 V7
 m133 I64
-m134 V7
-m135 V
-m136 vi
+m134 V7 b2 I64
+m135 V b2 I64
+m136 vi b2 viio/V
 m137 viio/V b1.5 V
 m138 b2.5 I
 m140 b2.5 I
 m142 b2.5 I
-m143 V65/V
-m144 V43/V
-m145 V43/V
-m146 V43/V
+m143 V65/V b2 V
+m144 V43/V b2 V
+m145 V43/V b2 V
+m146 V43/V b2 V65/V
 m147 I64 b2.75 V
 m148 I64 b2.75 V
 m149 I64

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/1/analysis.txt
@@ -1,34 +1,39 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - No.1: Moderato
+Title: String Quartet in C Major - 1: Moderato
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
-m1 C: I
+
+m0 b4.5 C: V
+m1 I b3 V43
 m2 I6
-m4 I
-m5 V7/IV
-m6 I
-m7 V
+m3 b4 V
+m4 I b3 IV
+m5 V7/IV b3 IV
+m6 I b2 V64 b3 I6 b4 V6/V
+m7 V b4 V7/V
 m8 V
+m9 b4 V/V
 m10 V b3 ii2/V
 m11 V7 b3 I64
 m12 V
+m13 b4.5 viio/V
 m14 V
 m15 I b3 V65
 m16 V7/IV b3 IV64 b4 ii2
 m17 V7/IV b3 IV64 b4 ii2
 m18 I
-m19 V7 b3 IV
+m19 V7 b2 I b3 IV
 m20 viio43/ii b1.5 ii6 b3 I64
 m21 V
 m22 ii/V b3 V7/V
-m23 V
+m23 V b3 V6/V
 m24 vi/V b3 iii6/V
 m25 ii6/V
 m26 V7/V
 m27 V7/V b3 V
-m28 viio7/V/V b2 V6/V b3 V7
+m28 viio7/V/V b2 V6/V b3 V7 b4 vi
 m29 I b2.5 V7/V b3 V
 m30 I b2 viio/V b3 iii/V b4 vi/V
 m31 ii/V b2 V7/V b3 V b4 V6/V b4.5 V
@@ -59,7 +64,7 @@ m57 v6
 m58 III/i
 m59 viio7/V/v
 m60 V/v
-m61 i
+m61 i b3 V64
 m62 i6 b4 V65/III
 m63 III b3 V2/V
 m64 v
@@ -77,12 +82,12 @@ m77 b2.5 viio b4 i
 m78 b2 viio65/iv b3 iv6
 m79 iv b1.5 V65/iv b2 iv b2.5 viio43/VII b3 VII6 b3.5 V7/III b4 vi/III b4.5 IV/III
 m80 III64 b3 V7/III
-m81 C: I
+m81 C: I b3 V
 m82 I
 m84 I b2 V65/IV b3 IV b4.5 V/V
 m85 V b3 V7
 m86 b3 I
-m87 viio43/V b2 V6 b3 V7
+m87 viio43/V b2 V6 b3 V7 b4 vi6
 m88 IV b2.5 V7 b3 I
 m89 IV b2 viio b3 iii b4 vi
 m90 ii b2 V6 b3 I b4 V7 b4.5 I64

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/1/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - 1: Moderato
+Title: String Quartet in C Major - No.1: Moderato
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/2/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - No.2: Adagio
+Title: String Quartet in C Major - 2: Adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
+
 m1 c: i b3 V6
 m2 i b2 iv6 b3 VII
 m3 III6 b2 VI b3 ii6 b4 V7

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/2/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - 2: Adagio
+Title: String Quartet in C Major - No.2: Adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/3/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - No.3: Menuetto: Allegretto
+Title: String Quartet in C Major - 3: Menuetto: Allegretto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
+
 m1 C: I
 m2 I
 m3 V7
@@ -68,5 +69,11 @@ m73 iv/V
 m74 vi/V
 m75 V/V
 m76 V6 b2 vii/V b3 V
-m77 V
+m77 V b3 III6
+m78 b3 V7
+m79 b3 i64
+m80 b3 V
+m81 b3 i64
+m82 b3 V
+m83 b3 viio6/V
 m84 V

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/3/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - 3: Menuetto: Allegretto
+Title: String Quartet in C Major - No.3: Menuetto: Allegretto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/4/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - 4: Fuga a quattro soggeti: Allegro
+Title: String Quartet in C Major - No.4: Fuga a quattro soggeti: Allegro
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No2/4/analysis.txt
@@ -1,57 +1,58 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in C Major - No.4: Fuga a quattro soggeti: Allegro
+Title: String Quartet in C Major - 4: Fuga a quattro soggeti: Allegro
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 6/8
-m1 C: None
+
+m1 C: V
 m2 I b2 ii6
 m3 I64 b2 ii
 m4 V65 b2 I
-m5 I
-m6 vi6 b2.67 V
+m5 I b2 IV
+m6 vi6 b2 V6/V b2.67 V
 m7 I6 b2 V7/V
 m8 V
 m9 I6 b2 ii65
 m10 V b1.67 I64 b2 ii65
-m11 V7
+m11 V7 b2 I
 m12 I b1.67 V2/IV b2 IV6
-m13 vi64 b2.67 V
+m13 vi64 b2 V7/V b2.67 V
 m14 I b2 V2/V
 m15 V6 b2.67 viio
 m16 I b2 ii65
 m17 V2 b1.67 I6 b2 IV2
 m18 V65 b2 I
-m19 ii65 b1.33 V b2.33 IV
-m20 viio65 b1.33 iii b2.33 ii
-m21 V65 b1.33 I b1.67 iii b2 ii6
-m22 I6 b2 viio6
-m23 vi6 b1.67 V7/vi
-m24 viio6
-m25 viio6
-m26 I6
-m27 IV2
-m28 ii7
+m19 ii65 b1.33 V b2 I b2.33 IV
+m20 viio65 b1.33 iii b2 IV64 b2.33 ii
+m21 V65 b1.33 I b1.67 iii b2 ii6 b2.33 V
+m22 I6 b1.33 IV b2 viio6 b2.33 V7/vi
+m23 vi6 b1.33 V7/iii b1.67 V7/vi b2 vi
+m24 viio6 b2 vi64
+m25 viio6 b2 V/V
+m26 I6 b1.33 V/iii b1.67 V2/vi b2 vi
+m27 IV2 b1.67 viio7 b2 V7/vi b2.67 vi
+m28 ii7 b1.33 viio6 b1.67 IV b2 V2/vi
 m29 vi b1.67 IV+64 b2 ii
 m30 V b1.67 I64 b2 vii b2.33 V2
 m31 I6 b2 V/V b2.67 V7
 m32 I b2.33 viio b2.67 viio64/IV
-m33 IV6
+m33 IV6 b2 V b2.67 V7/IV
 m34 IV b2.67 viio/IV/IV
 m35 IV/IV b1.67 It/i b2 V b2.67 viio
 m36 I b1.67 It/ii b2 V/ii b2.67 V7/ii
-m37 VI/ii b1.67 It/i
-m38 I
-m39 ii
-m40 IV/IV
+m37 VI/ii b1.67 It/i b2 V
+m38 I b1.33 V43/vi b1.67 It/ii b2 V/ii b2.67 viio/ii
+m39 ii b2.33 I+ b2.67 vi6
+m40 IV/IV b1.67 v6 b2.33 vi b2.67 IV6
 m41 v7 b1.67 ii6 b2 V7/ii b2.67 V7/ii
 m42 d: i b2 V b2.33 viio/V b2.67 V65
-m43 i b1.67 III
+m43 i b1.67 III b2 iio65
 m44 V65 b1.67 i b2 viio2 b2.67 iv6
 m45 V7 b2 ii
 m46 V/iv b2 iv6
-m47 i6 b1.67 iv6 b2.67 v7
-m48 VI6 b1.67 iv7 b2.67 III64
+m47 i6 b1.67 iv6 b2 iio7 b2.67 v7
+m48 VI6 b1.67 iv7 b2 V7/III b2.67 III64
 m49 V/III b1.67 V7/III
 m50 III
 m51 VI
@@ -59,57 +60,57 @@ m52 iv6/iv
 m53 VII
 m54 III+6
 m55 i
-m56 V
+m56 V b2.33 viio/V b2.67 V2
 m57 V6/IV b2.33 viio64 b2.67 V43/IV
 m58 IV b2.33 viio6/IV b2.67 V65/VII
 m59 C: I b2.67 V7/IV
-m60 IV
-m61 IV6
-m62 V6/V
-m63 V65/iii
+m60 IV b2 V6 b2.33 I b2.67 iii64
+m61 IV6 b1.33 viio b1.67 ii64 b2 V/vi b2.33 vi b2.67 I64
+m62 V6/V b1.33 V b1.67 V2 b2 I65 b2.33 IV b2.67 vi64
+m63 V65/iii b1.33 iii b1.67 viio6/vi b2 vi6
 m64 viio6/vi b1.67 iii64 b2 V/iii b2.33 viio/vii b2.67 V65/iii
 m65 e: i b2 viio65/III
 m66 V65 b1.67 i b2.33 iio b2.67 iv
 m67 V7 b2 i
 m68 i b1.33 viio b1.67 viio64/III b2 iv b2.33 V b2.67 iv
-m69 i6 b2 V6/III
-m70 VI6 b2 V/III b2.67 III6
+m69 i6 b1.67 VI b2 V6/III b2.67 III6
+m70 VI6 b1.67 iv7 b2 V/III b2.67 III6
 m71 V/III b1.33 viio6 b1.67 viio/III b2 III b2.67 V
-m72 VI b2.67 G: I
-m73 None b1.33 V/V b1.67 V7 b2 I b2.67 iii
-m74 ii6 b1.67 None b2 V2 b2.67 I6
+m72 VI b1.67 iv b2 V/III b2.67 G: I
+m73 b1.33 V/V b1.67 V7 b2 I b2.67 iii
+m74 ii6 b2 V2 b2.67 I6
 m75 IV b1.33 viio6 b1.67 I b2 V65
 m76 I b1.67 vi6 b2.67 V6
 m77 ii b2 V b2.67 I6
-m78 ii b2 V
+m78 ii b2 V b2.67 I
 m79 ii b1.67 viio b2 I6 b2.67 vi
-m80 ii43/IV b2 V7/IV
-m81 C: V b2.67 viio64
-m82 I6
+m80 ii43/IV b2 V7/IV b2.83 C: I
+m81 V b2.67 viio64
+m82 I6 b2 V/V b2.67 V7
 m83 I b2.67 viio/IV
 m84 ii b1.67 viio/ii b2 viio/V b2.33 V b2.67 V/vi
-m85 viio/iii b1.33 viio/vi b1.67 vi b2 IV b2.33 viio6/IV b2.67 None
+m85 viio/iii b1.33 viio/vi b1.67 vi b2 IV b2.33 viio6/IV
 m86 viio7/IV b1.33 V b1.67 V43/V b2 V65 b2.33 I b2.67 V/V/V
 m87 V43/vi b1.33 V65/ii b1.67 ii b2 v
-m88 V65/IV b2 IV
-m89 None b2 I6
+m88 V65/IV b2 IV b2.33 ii6
+m89 b2 I6
 m90 V6/ii b2 ii
 m91 V7/IV
 m92 IV6 b2 I6 b2.33 viio64 b2.67 viio6/IV
 m93 IV6 b2 v6
-m94 I64 b1.67 IV6 b2 v b2.33 viio/IV b2.67 IV
+m94 I64 b1.5 V43/IV b1.67 IV6 b2 v b2.33 viio/IV b2.67 IV
 m95 V43/IV b2 F: I
 m96 I b1.33 viio6
-m97 I
+m97 I b2 ii
 m98 vi6
 m99 V
-m100 V7/vi b2.67 iii
+m100 V7/vi b1.67 IV b2.67 iii
 m101 IV
 m103 It/vi b2 vi64
 m104 V7/vi b2 vi64
 m105 V7/vi b2.67 vi64
-m106 iio/ii
-m107 g: Ger7
+m106 iio/ii b1.67 VI6/ii b2 viio7/ii b2.67 g: i
+m107 Ger7
 m108 i64
 m109 viio7/V
 m110 V7/IV/IV
@@ -122,10 +123,10 @@ m116 IV b2 I64
 m117 vi b1.67 V7 b2 I64
 m118 viio2/V
 m119 V
-m120 v6
-m121 vi6
-m122 vi6
-m123 ii
+m120 v6 b2 V6
+m121 vi6 b2 vi
+m122 vi6 b2 V6/ii
+m123 ii b2 V6
 m124 I
 m125 v b2 V
 m126 vi64
@@ -154,8 +155,8 @@ m148 I64
 m149 i64 b2 I64
 m150 IV b2 V64/V
 m151 V b2.67 V2
-m152 I6
-m153 V7 b1.67 I
+m152 I6 b2 IV6
+m153 V7 b1.67 I b2 IV
 m154 V7 b1.67 I6 b2.33 ii7
 m155 V65 b1.67 I b2 ii6 b2.67 V
 m156 I

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/1/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - 1: Allegro con spirito
+Title: String Quartet in G Minor - No.1: Allegro con spirito
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/1/analysis.txt
@@ -1,10 +1,12 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - No.1: Allegro con spirito
+Title: String Quartet in G Minor - 1: Allegro con spirito
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 2/4
-m1 g: i b2.5 VI6
+
+m0 b2.5 g: i
+m1 i b2.5 VI6
 m2 V6 b2.5 V7
 m3 i b2.5 iv
 m4 V b2.5 i64
@@ -38,7 +40,7 @@ m34 I
 m35 V7/IV
 m36 IV
 m37 V65/ii
-m38 ii
+m38 ii b2.5 V65
 m39 I
 m40 ii6
 m41 V
@@ -53,7 +55,7 @@ m49 I
 m50 V7/IV
 m52 viio65/ii
 m53 ii6 b2 V43/ii
-m54 ii b2 None
+m54 ii
 m55 V6 b2 V7
 m56 vi b2 V65/IV
 m57 IV
@@ -90,7 +92,6 @@ m90 ii6
 m91 It/vi
 m92 V/vi
 m93 viio43/vi
-m94 viio43/vi b2.5 V2/vi
 m95 d: iv
 m96 i6 b2.5 VII
 m97 i

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/2/analysis.txt
@@ -1,10 +1,12 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - No.2: Menuetto: Allegretto
+Title: String Quartet in G Minor - 2: Menuetto: Allegretto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
-m1 g: i b2 iio b3 i6
+
+m0 b3 g: V
+m1 i b2 iio b3 i6
 m2 iv b3 i6
 m3 viio6 b3 V43
 m4 viio65
@@ -20,8 +22,8 @@ m13 ii b2 viio6/ii b3 ii6
 m14 V b3 ii6
 m15 iii b2 ii6 b3 iii6
 m16 vi b3 V64/V
-m17 V
-m18 V7
+m17 V b3 I64
+m18 V7 b3 I64
 m19 viio43
 m20 V2
 m21 ii

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/2/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - 2: Menuetto: Allegretto
+Title: String Quartet in G Minor - No.2: Menuetto: Allegretto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/3/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - 3: Poco adagio
+Title: String Quartet in G Minor - No.3: Poco adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/3/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - No.3: Poco adagio
+Title: String Quartet in G Minor - 3: Poco adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
+
 m1 G: I
 m2 V65 b3 I
 m3 IV b2 V2 b3 I6
@@ -19,7 +20,7 @@ m13 I64
 m14 V
 m15 V7/V
 m16 V64
-m17 vi6
+m17 vi6 b3.75 V65/V/V
 m18 V/V
 m19 b3 V64
 m20 V7/V b3 V64
@@ -46,15 +47,15 @@ m41 I b3 V7
 m42 I b3 V7
 m43 I
 m44 I
-m45 V65
-m46 IV
-m47 V65
+m45 V65 b3 I
+m46 IV b2 viio64 b3 I6
+m47 V65 b2 I
 m48 d: i
 m50 V65/v
 m51 a: i
-m52 V7
-m53 iv6
-m54 V64
+m52 V7 b3 i6
+m53 iv6 b2 i64
+m54 V64 b2 i6
 m55 i
 m56 V2/iv
 m57 V7/ii b2 viio7/ii
@@ -65,6 +66,7 @@ m61 viio7
 m62 i
 m63 Ger7
 m64 V
+m65 b3 V/III
 m66 C: I
 m67 V6 b3 I
 m68 IV b2 V2 b3 I6

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/4/analysis.txt
@@ -1,10 +1,12 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - No.4: Allegro di molto
+Title: String Quartet in G Minor - 4: Allegro di molto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
-m1 g: i b3 V2
+
+m0 b4.5 g: V
+m1 i b3 V2
 m2 i6 b3 viio6
 m3 V7
 m5 i b3 V2

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No3/4/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in G Minor - 4: Allegro di molto
+Title: String Quartet in G Minor - No.4: Allegro di molto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/1/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - 1: Allegro di molto
+Title: String Quartet in D Major - No.1: Allegro di molto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/1/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - No.1: Allegro di molto
+Title: String Quartet in D Major - 1: Allegro di molto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
+
 m1 D: I
 m3 V7
 m4 I b2 viio7 b3 I
@@ -15,7 +16,7 @@ m15 V7
 m16 I b2 viio7 b3 I
 m19 ii
 m20 b3 ii2
-m21 V65
+m21 V65 b3 I
 m22 ii65
 m23 I64 b3 V7
 m24 vi
@@ -31,7 +32,7 @@ m35 V
 m37 a: i
 m39 Ger7
 m41 V b3 viio/V
-m42 V
+m42 V b3 V2
 m43 A: I6
 m44 V
 m45 I b2 IV b3 viio/V
@@ -50,7 +51,7 @@ m57 ii6
 m58 I6
 m61 V43
 m63 I6
-m64 None b3 I6
+m64 b3 I6
 m65 V43 b3 I
 m66 ii6 b3.67 V7
 m67 I
@@ -141,12 +142,12 @@ m173 V
 m175 V7 b3 i
 m176 V2 b3 i6
 m177 V7 b3 i
-m178 iv7
-m179 III7
-m180 iio7
-m181 i b3 None
+m178 iv7 b3 -VII7
+m179 III7 b3 VI7
+m180 iio7 b3 V7
+m181 i
 m182 V65/iv b2 IV b3 iv
-m183 V b2 None b3 IV6
+m183 V b3 IV6
 m184 V65 b2 i b3 V64
 m185 i6 b2 V65/iv
 m186 iv b2 viio/V
@@ -176,7 +177,7 @@ m221 I b3 IV64
 m222 I
 m223 ii
 m224 b3 ii2
-m225 V65
+m225 V65 b3 I
 m226 IV b3 ii6
 m227 I64 b3 V7
 m228 vi
@@ -189,7 +190,7 @@ m234 V
 m236 V7 b3 I
 m237 V2 b3 I6
 m238 V7 b3 I
-m239 IV7
+m239 IV7 b2 ii6
 m240 V2
 m241 I6
 m242 IV
@@ -221,7 +222,7 @@ m273 V/IV
 m275 IV
 m276 viio/ii b3 ii
 m277 viio7 b3 I
-m278 viio/ii
+m278 viio/ii b2 ii6 b3 ii65
 m279 V2
 m281 I
 m282 b2 IV
@@ -236,6 +237,8 @@ m291 I b2 ii
 m292 I64 b3 V7
 m293 I b3 iii
 m294 I6
+m295 b3 v
+m296 b2 I b3 viio/IV
 m297 I6 b2 I
 m298 b3 N/vi
 m299 I b3 iii

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/2/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - 2: Un poco Adagio affettuoso
+Title: String Quartet in D Major - No.2: Un poco Adagio affettuoso
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/2/analysis.txt
@@ -1,49 +1,51 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - No.2: Un poco Adagio affettuoso
+Title: String Quartet in D Major - 2: Un poco Adagio affettuoso
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 2/4
+
 m0 b2.5 d: V
-m1 i b2 viio6 b2.5 i
-m2 V2 b1.5 i6 b2 viio43
-m3 i6 b1.5 VI b2 iio6 b2.5 V
-m4 i
-m5 i6 b2 viio6 b2.5 i
-m6 iv7 b2 bVII7
-m7 i7 b1.5 VI b2 III64 b2.5 V7/III
+m1 i b1.5 i6 b2 viio6 b2.5 i
+m2 V2 b1.5 i6 b2 VI b2.5 viio43
+m3 i6 b1.5 VI b2 iio6 b2.5 V7
+m4 i b2.5 V
+m5 i b1.5 i6 b2 viio b2.5 i
+m6 iv7 b2 -VII7
+m7 VI6 b1.5 VI b2 V/III b2.5 V7/III
 m8 III
-m9 III b2 iv b2.5 v
-m10 iv6 b1.5 viio43/iv b2 iv6
+m9 III b1.5 viio7/iv b2 iv b2.5 v
+m10 iv6 b1.5 viio43/iv b1.88 iv6
+m11 b1.5 Ger7
 m12 V b2.5 V/iv
 m13 N6
 m14 viio65/iv
 m15 iv6
 m16 Ger7
-m17 i64
-m18 i b2.5 V
-m19 i
-m20 viio43 b2.5 viio43
+m17 i64 b2 V7
+m18 i
+m19 i b1.5 i6 b2 viio6 b2.5 i
+m20 viio43 b1.5 i6 b2.5 viio43
 m21 i6 b1.5 VI b2 iio65 b2.5 V7
 m22 i
 m23 i b1.5 i6 b2 viio6 b2.5 i
 m24 iv7 b2 VII
-m25 III b2 III64
+m25 III b1.5 VI7 b2 III64 b2.5 V7/III
 m26 III
-m27 III
-m28 iv6
-m29 VI
+m27 III b1.5 viio/iv b2 iv b2.5 viio65/iv
+m28 iv6 b2 iv6
+m29 VI b2 Ger7
 m30 i64 b2 V b2.5 V6/iv
-m31 iv
+m31 iv b2 N6
 m32 viio65/iv
 m33 iv
 m34 b2 viio65/V
 m35 i64
-m36 V b2 i b2.5 V
+m36 V b2 i
 m37 i b2 viio b2.5 i
 m38 viio2 b1.5 i64 b2 V b2.5 V7
 m39 VI b2 viio64
-m40 i6
+m40 i6 b2.5 V
 m41 i b2 viio6 b2.5 i
 m42 iv7 b2 V7/III
 m43 III6 b1.5 iv64 b2 III b2.5 V7/III
@@ -52,20 +54,20 @@ m45 viio64/iv b2 iv6 b2.5 viio7/iv
 m46 iv
 m47 iio64
 m48 i b2 V6 b2.5 V6/iv
-m49 iv
-m50 v
-m51 VI
+m49 iv b1.5 iv/iv
+m50 v b1.5 viio43/iv
+m51 VI b1.5 iv64
 m52 Ger7
 m53 i64 b2.5 V65
-m54 b2 i b2.5 V
+m54 b2 i
 m55 i b1.5 i6 b2 V43 b2.5 i
-m56 iv b1.5 i6 b2 None b2.5 viio64
+m56 iv b1.5 i6 b2.5 viio64
 m57 i6 b1.5 VI b2 iv b2.5 V
 m58 i
 m59 b1.5 i6 b2 V64 b2.5 i
 m60 VI64 b2 V7/III
 m61 III b1.5 VI b2 V/III
-m62 III b2.5 V
+m62 III
 m63 b1.5 viio7/iv b2 iv b2.5 viio65/iv
 m64 iv6 b1.5 iv/iv b2 iv
 m65 b2 viio65/V
@@ -76,22 +78,23 @@ m69 iv6
 m70 Ger7
 m71 i64 b2 V
 m72 i
-m73 i b2 viio6 b2.5 i
-m74 V2 b1.5 i6 b2 VI
-m75 i6 b1.5 VI b2 iio65
+m73 i b1.5 i6 b2 viio6 b2.5 i
+m74 V2 b1.5 i6 b2 VI b2.5 viio43
+m75 i6 b1.5 VI b2 iio65 b2.5 V65
 m76 i b2.5 V
-m77 i b2 viio b2.5 i
+m77 i b1.5 i6 b2 viio b2.5 i
 m78 iv7 b2 -VII7
-m79 III b1.5 VI b2 V/III
+m79 III b1.5 VI b2 V/III b2.5 V7/III
 m80 III
-m81 III b2 iv b2.5 v
+m81 III b1.5 viio7/iv b2 iv b2.5 v
 m82 iv6 b1.5 viio43/iv b2 iv6
+m83 b1.5 Ger7
 m84 V b2.5 V/iv
 m85 N6
 m86 viio65/iv
 m87 iv6
 m88 Ger7
-m89 i64
+m89 i64 b2 V
 m91 b2.5 viio64
 m93 viio7
 m94 i b2 VI

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/3/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - 3: Menuetto alla zingarese
+Title: String Quartet in D Major - No.3: Menuetto alla zingarese
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/3/analysis.txt
@@ -1,11 +1,12 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - No.3: Menuetto alla zingarese
+Title: String Quartet in D Major - 3: Menuetto alla zingarese
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
+
 m0 b3 D: V
-m1 I b2 V6
+m1 I b2 V6 b3 V
 m2 I b2 IV b3 ii6
 m3 V7
 m4 b3 V7/V
@@ -13,16 +14,18 @@ m5 V
 m6 V/V b2 V b3.5 V/V
 m7 V b2 vi6 b3 V7/V
 m8 I
-m9 I6 b2 ii
+m9 I6 b2 ii b3 V7
 m10 I b2 IV
-m11 ii
+m11 ii b3 viio
 m12 b2 V
-m13 I
-m16 b3 V43
+m13 I b3 I6
+m14 b2 IV
+m15 b3 viio
+m16 b2 ii b3 V43
 m17 I
 m18 V7 b2 I b3 V7
 m19 I b2 ii b3 V7
-m20 I
+m20 I b3 V
 m21 I b2 vi b3 I6
 m22 ii65
 m23 viio6 b2 V7 b3 V43

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/4/analysis.txt
@@ -1,10 +1,12 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - No.4: Presto e scherzando
+Title: String Quartet in D Major - 4: Presto e scherzando
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
-m1 D: I b3 viio
+
+m0 b4.5 D: V
+m1 I b3 viio
 m2 I6 b2 viio7/ii b3 ii
 m3 ii b3 i6
 m4 V b2 viio6/V b3 V6
@@ -22,15 +24,15 @@ m16 V6 b2.5 V65 b3 i b4 ii6 b4.5 viio/ii
 m17 ii b2 ii6 b2.5 viio/ii b3 ii b4 ii6 b4.5 ii
 m18 I64 b3 V
 m19 A: I b2 V7 b3 I6 b4 V7
-m20 I6
+m20 I6 b2 V43 b3 I b4 V65
 m21 I
 m22 a: i
 m23 VI
 m24 b2 V65/VI
 m25 b4 VI
 m26 b4 Ger7
-m28 V
-m29 V
+m28 V b4 Ger7
+m29 V b4 Ger7
 m30 V
 m31 IV
 m32 b2 viio b3 V65
@@ -39,7 +41,7 @@ m34 ii6 b2 V6/V b3 V b4 V+
 m35 iii6 b2 V6/vi b3 vi b4 ii64
 m36 IV6 b3 viio b4 vii
 m37 V6 b3 I
-m38 ii6 b4 I
+m38 ii6 b3 V65 b4 I
 m39 V65 b2 I b3 ii6 b4 V
 m40 I b3 ii6 b4 I64
 m41 IV6 b2 I64 b3 IV6 b4 I64
@@ -50,20 +52,20 @@ m45 ii65 b2 I6 b3 ii65 b4 V
 m46 I
 m48 V7/IV
 m50 b: viio7 b3 III+64 b4 viio
-m51 i
+m51 i b3 iv43
 m52 V7/III
 m53 V7/VI
 m54 viio7/iv b2 V65/iv
 m55 iv b3 iio6 b4 viio7/V
-m56 V
+m56 V b4 V7
 m57 i6 b2 V2 b3 V65
-m58 i b3 V/iv
+m58 i b3 V/iv b4 V7/iv
 m59 iv6 b2 V2/iv b3 V65/iv
-m60 iv b3 V/VII
+m60 iv b3 V/VII b4 V7/VII
 m61 VII6 b2 V2/VII b3 V65/VII
-m62 VII b3 V/III
+m62 VII b3 V/III b4 V7/III
 m63 III6 b2 V2/III b3 V65/III
-m64 III b3 V/VI
+m64 III b3 V/VI b4 V7/VI
 m65 VI b2 V2/VI b3 V65/VI
 m66 VI
 m67 b4 It
@@ -93,7 +95,7 @@ m93 V b2 V6 b3 i b4 V7
 m94 i6 b2 V65 b3 i b4 i6
 m95 V
 m96 I b2 V7 b3 I6 b4 V7
-m97 I6
+m97 I6 b2 V43 b3 I b4 V65
 m98 I
 m99 d: i
 m100 VI
@@ -101,8 +103,8 @@ m101 b2 III65
 m102 b4 VI
 m103 b4 Ger7
 m104 b4 iv6
-m105 V
-m106 V
+m105 V b4 It
+m106 V b4 It
 m107 V
 m108 iv
 m109 b3 V7
@@ -111,7 +113,7 @@ m111 ii6 b2 V6/V b3 V b4 V+
 m112 iii6 b2 V6/vi b3 vi b4 IV6
 m113 IV6 b3 viio b4 vii
 m114 V6 b3 I
-m115 IV b4 I
+m115 IV b2 ii b3 V65 b4 I
 m116 V65 b2 I b3 ii b4 V7
 m117 I b2 I6 b3 ii65 b4 I64
 m118 IV6 b2 I64 b3 IV6 b4 I64
@@ -122,7 +124,7 @@ m122 ii65 b2 I6 b3 ii65 b4 V
 m123 I
 m124 I
 m125 viio7/iv/vi
-m126 iv/vi
+m126 iv/vi b3 viio7/vi
 m127 I
 m129 IV64 b4 viio
 m130 viio b3 I

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No4/4/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in D Major - 4: Presto e scherzando
+Title: String Quartet in D Major - No.4: Presto e scherzando
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/1/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - 1: Moderato
+Title: String Quartet in F Minor - No.1: Moderato
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/1/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - No.1: Moderato
+Title: String Quartet in F Minor - 1: Moderato
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
+
 m1 f: i
 m2 V7
 m3 i
@@ -17,7 +18,7 @@ m10 V b3 i b4 V/V
 m11 V b3 i b4 Ger7
 m12 V
 m14 Ab: iii
-m15 IV b4 viio65/ii
+m15 IV b3 ii6 b4 viio65/ii
 m16 ii b2 V7/ii b3 ii b4 V7/V
 m17 V7
 m18 b2 V7
@@ -25,7 +26,7 @@ m20 I
 m21 V
 m22 IV b3 iii
 m23 ii b3 I
-m24 V
+m24 V b2 I b3 ii b4 V7/V
 m25 V b3 V7/V
 m26 V b3 V7/V
 m27 V
@@ -39,13 +40,13 @@ m37 b3 V2
 m38 Ab: I6 b3 V7
 m39 I b2 V7 b3 I b4 V7
 m40 I
-m41 IV
+m41 IV b3 ii
 m42 I64 b3 V7
 m43 vi b3 iii
 m44 ii b3 I
 m45 V7 b2 I b3 ii b4 I64 b4.5 V7
-m46 I b3 iv
-m47 I b3 iv
+m46 I b3 iv b4 viio7
+m47 I b3 iv b4 V
 m48 I b3 viio7/vi
 m49 I b2 IV b3 viio7 b4 V7/IV
 m50 Db: I
@@ -64,7 +65,7 @@ m63 V/IV/iii
 m64 IV/iii
 m66 V/V/iii
 m67 V/iii
-m69 f: i
+m69 f: i b2.75 VI6 b3.5 viio7/V/v
 m70 V/v
 m72 b3 V2/v
 m73 c: i b3 V65
@@ -75,7 +76,7 @@ m77 i
 m78 V7/VI
 m79 VI
 m80 V7/iv
-m81 f: i
+m81 f: i b3 Ger7
 m82 V7
 m86 i
 m87 V7
@@ -90,11 +91,11 @@ m95 IV7
 m96 V7/V
 m97 V
 m98 V7
-m99 i b3 -VII
+m99 i b3 -VII b4 III
 m100 VI7 b3 V7
-m101 VI7
+m101 VI7 b3 v7
 m102 iv7
-m103 V
+m103 V b2 V7 b4 V65/V
 m104 V b3 viio7/V
 m105 V b3 viio7/V
 m106 V b3 V/V
@@ -120,8 +121,8 @@ m131 i64 b3 V7
 m132 vi b3 iii
 m133 ii b3 i6
 m134 V43 b2 i b3 ii b4 i64 b4.5 V7
-m135 i b3 iv
-m136 i b3 iv
+m135 i b3 iv b4 viio7
+m136 i b3 iv b4 viio7
 m137 i b3 V7/VI
 m138 i b3 V7/VI
 m139 Db: I
@@ -129,7 +130,7 @@ m140 V7
 m141 V7/IV
 m142 Gb: I
 m143 V
-m144 i
+m144 i b3 IV
 m145 V7/III b3 III
 m146 b3 V7
 m147 i b3 V7/V

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/2/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - 2: Menuetto
+Title: String Quartet in F Minor - No.2: Menuetto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/2/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - No.2: Menuetto
+Title: String Quartet in F Minor - 2: Menuetto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
+
 m1 f: i
 m2 V43
 m3 i6 b2 i b3 viio65/V
@@ -26,11 +27,11 @@ m19 V7/iv
 m20 iv
 m21 viio43/iv
 m22 iv6
-m23 V
-m24 V
-m25 i6 b3 It
+m23 V b2 i
+m24 V b2 V6 b3 V64
+m25 i6 b2 i b3 It
 m26 V b2 V6 b3 V64
-m27 i6 b3 It
+m27 i6 b2 i b3 It
 m28 V
 m29 viio6
 m30 i
@@ -46,11 +47,11 @@ m39 i6
 m40 V7/VI
 m41 VI
 m42 viio7/iv
-m43 iv b3 V65/V
+m43 iv b2 iv7 b3 V65/V
 m44 V b3 viio7/V
 m45 V b2 viio7/V b3 V
 m46 V7
-m47 viio43
+m47 viio43 b2 III+ b3 viio6
 m48 i b3 i6
 m49 iio65 b3 V7
 m50 i b3 i6

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/3/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - No.3: Adagio
+Title: String Quartet in F Minor - 3: Adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 6/8
+
 m1 F: I
 m2 ii2
 m3 V65
@@ -13,21 +14,21 @@ m6 V7 b2 vi
 m7 IV b2 IV b2.33 viio6/ii b2.67 ii
 m8 I64 b1.67 V7 b2 I
 m9 I
-m10 viio6 b1.67 vi6
+m10 viio6 b1.67 vi6 b2 vii
 m11 V65
 m12 I
-m13 IV
+m13 IV b2 ii65
 m14 V6 b2 I6 b2.67 I
 m15 ii7 b2 V65 b2.67 I
-m16 ii6 b2 I
+m16 ii6 b1.67 V7 b2 I
 m17 I
 m18 viio6/vi b2 vi
 m19 I b2.33 V65/ii
-m20 ii
+m20 ii b2.67 viio6/V
 m21 V6 b2 vi7 b2.67 V/V
-m22 V b2 V/V
+m22 V b2 V/V b2.67 viio64/V
 m23 V6 b2 vi7 b2.67 V/V
-m24 V b1.67 V b2 V/V
+m24 V b1.67 V b2 V/V b2.67 viio64/V
 m25 V6 b2.67 V65
 m26 I b2 vi6
 m27 V64 b2 V64 b2.67 V7/V
@@ -37,7 +38,7 @@ m30 V
 m31 I6 b2 viio65/ii
 m32 V64 b2 V7/V
 m33 V64 b2 V7/V
-m34 V64
+m34 V64 b2 V7/V
 m35 V b1.33 I6 b1.67 V6 b2 I b2.33 V43/V b2.67 V
 m36 V65/V
 m37 V65/V b1.67 V b2 vi6
@@ -63,10 +64,10 @@ m57 I
 m58 ii7
 m59 V7
 m60 I
-m61 IV
+m61 IV b2 ii6
 m62 ii7 b1.67 V2 b2 I6 b2.67 I
-m63 ii b1.67 ii2 b2.67 I
-m64 ii6 b2 V
+m63 ii b1.67 ii2 b2 V65 b2.67 I
+m64 ii6 b1.67 viio/V b2 V
 m65 I6 b2 ii7 b2.67 V
 m66 I b2 V b2.67 viio64
 m67 I6 b2 ii7 b2.67 V

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/3/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - 3: Adagio
+Title: String Quartet in F Minor - No.3: Adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/4/analysis.txt
@@ -1,15 +1,16 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - No.4: Fuga a due soggetti
+Title: String Quartet in F Minor - 4: Fuga a due soggetti
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
+
 m1 f: V
-m2 i
-m3 viio
-m4 iv
-m5 iv6
-m6 V6
+m2 i b3 VI
+m3 viio b2 viio64
+m4 iv b3 i6
+m5 iv6 b2 V b3 iv
+m6 V6 b4 viio
 m7 i
 m8 i6 b3 i
 m9 V7/V
@@ -20,10 +21,10 @@ m13 V7
 m14 i b3 iv6
 m15 V65
 m16 i
-m17 i6
+m17 i6 b3 i
 m18 V43/V b3 V7/V
 m19 V
-m20 i6
+m20 i6 b3 iv
 m21 V2
 m22 b3 i6 b4 i
 m23 V65
@@ -43,7 +44,7 @@ m36 V
 m37 i6 b3 i
 m38 V65/III
 m39 III
-m40 III
+m40 III b3 VI
 m41 V7/III
 m42 V7/VI
 m43 viio7/iv
@@ -59,7 +60,7 @@ m52 V/III b3 V65/III
 m53 V/VI
 m54 V65/iv
 m55 iv
-m56 iv6
+m56 iv6 b3 iv/iv
 m57 V7/iv
 m58 bb: i
 m59 V7/VII
@@ -67,17 +68,17 @@ m60 iv/iv
 m61 V7/VI
 m62 VI b3 iv7
 m63 V65/VI
-m64 VI
+m64 VI b3 iv
 m65 V65/VI
 m66 Gb: I
 m68 V2/V
 m69 Db: I
 m71 V2/V
 m72 Ab: I
-m73 I
+m73 I b3 i
 m74 V2/v
 m75 eb: i
-m77 viio7/v
+m77 viio7/v b3 V2/v
 m78 bb: i
 m80 viio7/v b3 V2/v
 m81 f: i
@@ -89,7 +90,7 @@ m87 VI b3 iv
 m88 V7
 m89 i b3 V7/iv
 m90 f: i b3 VI
-m91 V6
+m91 V6 b4 V65
 m92 i
 m93 i6 b3 viio65
 m94 viio43
@@ -106,27 +107,27 @@ m104 V7 b3 VI
 m105 V7
 m106 i64
 m107 viio7/V
-m108 i64
+m108 i64 b3 V
 m109 V7 b4 i64
 m110 iio6
 m111 viio7
 m112 i
-m113 i6
+m113 i6 b3 VI6
 m114 V2 b3 i6
-m115 viio64/V
+m115 viio64/V b3 V2/V
 m116 V
 m117 i
 m118 V65 b3 i
 m119 viio43/V b3 V2/V
 m120 V64 b3 V6
-m121 i6
+m121 i6 b3 i
 m122 iv b3 iio
 m123 V2
 m124 i
 m125 V65
 m126 i b3 i7
 m127 VI b3 iv65
-m128 VII
+m128 VII b4 V2/III
 m129 III6 b3 V65/VI
 m130 VI
 m131 iv
@@ -136,13 +137,11 @@ m134 V
 m135 i64
 m136 V b3 i64
 m137 viio43/V
-m138 V
+m138 V b3 i64
 m139 viio7/V
 m140 viio43
 m141 i64
-m142 None
 m143 V b3 i64
-m144 None
 m145 V
 m146 i
 m147 viio7 b3 V7
@@ -157,7 +156,7 @@ m155 v
 m156 viio65/V b3 viio7/V
 m157 iv6 b3 iv
 m158 V7 b3 i
-m159 iio65
+m159 iio65 b3 V7
 m160 i
 m161 V65
 m162 i
@@ -171,9 +170,9 @@ m169 viio43
 m170 i6
 m171 viio43/V
 m172 V6
-m173 iio
+m173 iio b4 iv43
 m174 viio
-m175 viio7
+m175 viio7 b2 iio b4 iv43
 m176 viio7
 m179 i
 m180 i6 b3 iv

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No5/4/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in F Minor - 4: Fuga a due soggetti
+Title: String Quartet in F Minor - No.4: Fuga a due soggetti
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/1/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - 1: Allegro di molto e scherzando
+Title: String Quartet in A Major - No.1: Allegro di molto e scherzando
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/1/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/1/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - No.1: Allegro di molto e scherzando
+Title: String Quartet in A Major - 1: Allegro di molto e scherzando
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 6/8
+
 m1 A: I
 m2 b1.67 V b2 I
 m3 V b2 I
@@ -29,7 +30,7 @@ m26 I b1.67 V7 b2 I b2.67 V7
 m27 I b1.67 V7 b2 I b2.33 V b2.67 I
 m28 V7 b1.33 I b1.67 V7 b2 I b2.33 V7 b2.67 I
 m29 V7
-m31 i
+m31 i b2 iv7
 m32 D: I7 b2 I
 m33 IV b2 V7
 m34 I
@@ -39,15 +40,15 @@ m37 ii b2 V7/VI
 m38 E: V
 m39 b1.33 viio7/V b1.67 V b2.33 viio7/V b2.67 V
 m40 b1.33 viio7/V b1.67 V b2.33 viio7/V b2.67 V
-m42 I
+m42 I b2 V
 m43 I b1.33 V7 b1.67 I b2 IV b2.67 ii
 m44 I64 b1.67 V7 b2 I
-m45 i
+m45 i b2 V7
 m46 b1.33 viio7/V b2 V
 m47 b1.67 i64 b2 V b2.67 V7
 m48 b1.67 i64 b2 V b2.67 viio7/V
-m49 V b1.67 i64 b2.67 viio7/V
-m50 V b1.67 viio7/V
+m49 V b1.67 i64 b2 V b2.67 viio7/V
+m50 V b1.67 viio7/V b2 V
 m51 b1.67 I
 m53 V b2 I b2.33 V7 b2.67 I
 m54 IV b2 I64 b2.67 V
@@ -59,7 +60,7 @@ m59 I b2.67 V7
 m60 I b2.67 V7
 m61 I b2 IV
 m62 I b2 IV
-m63 I b2 V7
+m63 I b2 V7 b2.67 IV
 m64 V7/IV
 m65 V7/IV
 m66 b: V7 b2 i
@@ -120,7 +121,7 @@ m126 I b1.67 V7 b2 I b2.67 V7
 m127 I b1.67 V7 b2 I b2.33 V7 b2.67 I
 m128 V7 b1.33 I b1.67 V7 b2 I b2.33 V7 b2.67 I
 m129 V7
-m131 i
+m131 i b2 iv7
 m132 G: I7 b2 I
 m133 IV b2 V7
 m134 I
@@ -130,13 +131,15 @@ m137 i b2 V7/V
 m138 V
 m139 viio7/V b1.67 V b2 viio7 b2.67 V
 m140 viio7 b1.67 V b2 viio7 b2.67 V
-m142 I
+m142 I b2 V
 m143 I b1.67 V7 b2 IV b2.67 ii
 m144 I64 b1.67 V7 b2 I
-m145 i
+m145 i b2 V
+m146 b1.67 viio7/V b2 V
 m147 i64 b2 V
 m148 i64 b2 V
-m149 i64
+m149 i64 b2 V
+m152 b2.67 I
 m153 V b2 I
 m154 IV b2 I b2.67 V7
 m155 I

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/2/analysis.txt
@@ -1,82 +1,83 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - No.2: Adagio
+Title: String Quartet in A Major - 2: Adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
-m1 E: I b4 V7
-m2 I b4 V7
+
+m1 E: I b3 V43 b4 V7
+m2 I b3 V43 b4 V7
 m3 I
 m4 IV b2 I
-m5 ii b4 V7
-m6 I b4 I6
+m5 ii b2 IV64 b3 V65 b4 V7
+m6 I b2 iii64 b3 vi b4 I6
 m7 ii6 b4 V7
-m8 I b2 IV
-m9 I b4 V7
-m10 I b2 I6 b4 V7
+m8 I b2 IV b3 V6 b4 viio6
+m9 I b2 I6 b3 V43 b4 V7
+m10 I b2 I6 b3 V43 b4 V7
 m11 I b3 V7/IV
 m12 IV64 b3 viio
 m13 I
-m14 I64 b2 V
+m14 I64 b2 V b4 viio6/V
 m15 V6 b4 V+65
-m16 I b4 V65/ii
+m16 I b2 I+ b3 vi b4 V65/ii
 m17 V/V b3 viio7/ii b4 viio/IV
 m18 V/V b3 viio7/ii b4 viio/IV
 m19 V/V b3 V7/V
 m21 V6 b3 V65
-m22 I
+m22 I b3 viio6
 m23 I64
 m24 V64 b3 V7/V
-m25 V b3 I b4 V7/V
-m26 V b3 I b4 V7/V
+m25 V b2 V65 b3 I b4 V7/V
+m26 V b2 V+6 b3 I b4 V7/V
 m27 viio/V b3 V
-m28 I b4 V7
-m29 I b4 V7
+m28 I b3 viio b4 V7
+m29 I b3 viio b4 V7
 m30 I
 m31 IV b2 I
-m32 ii b4 V7
-m33 I b2 iii64 b4 I6
+m32 ii b2 IV64 b3 V6 b4 V7
+m33 I b2 iii64 b3 vi b4 I6
 m34 ii6 b4 V7
-m35 viio b2 I
-m36 I b4 V7
-m37 I b2 I6 b4 V7
+m35 viio b2 I b3 I6 b4 viio6
+m36 I b2 I6 b3 V65 b4 V7
+m37 I b2 I6 b3 V65 b4 V7
 m38 I b3 V7/IV
 m39 IV64 b3 viio
 m40 I
-m41 I64 b2 V
+m41 I64 b2 V b4 viio6/V
 m42 V6
-m43 I b2 I+ b4 vi6
+m43 I b2 I+ b3 vi b4 vi6
 m44 V/V b3 viio7/ii b4 viio/IV
 m45 V/V b3 viio7/ii b4 viio/IV
 m46 V/V b2 V7/V
 m48 V6 b3 V65
-m49 I
+m49 I b3 viio2/iii
 m50 I
 m51 V64 b3 V7/V
-m52 V
-m53 V b2 V6
+m52 V b2 V6 b3 V43/V
+m53 V b2 V6 b3 V43/V
 m54 v
 m55 V2/ii
 m56 ii6
 m57 V7/vii
 m58 vi64
-m59 V/vi
-m60 vi6
-m61 ii
-m62 I
-m63 IV
+m59 V/vi b4 V2/vi
+m60 vi6 b3 V65/ii
+m61 ii b3 V65
+m62 I b3 V65/IV
+m63 IV b3 V65/V
 m64 V b3 V2
-m65 I6
-m66 IV b4 II+6
-m67 V
-m68 vi
+m65 I6 b3 I+6
+m66 IV b2 IV+ b3 ii b4 II+6
+m67 V b2 V+ b3 iii b4 V6/vi
+m68 vi b2 IV6 b3 viio6/V
 m69 V b3 viio7/V
 m70 V b3 viio7/V
 m71 V b3 V7
-m73 i
+m73 i b3 i2
 m74 Ger7
 m75 I64
 m76 I64 b3 V7
-m77 I b3 IV b4 V7
-m78 I b3 IV b4 V7
+m77 I b2 V+65/IV b3 IV b4 V7
+m78 I b2 V+65/IV b3 IV b4 V7
 m79 viio b3 I

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/2/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/2/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - 2: Adagio
+Title: String Quartet in A Major - No.2: Adagio
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/3/analysis.txt
@@ -1,9 +1,10 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - No.3: Menuetto
+Title: String Quartet in A Major - 3: Menuetto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 3/4
+
 m1 A: I
 m2 V43 b2 I
 m3 iii6 b3 V7
@@ -37,6 +38,6 @@ m36 I
 m37 I b2 viio b3 vi
 m38 V
 m39 V7
-m40 vii b3 I
+m40 vii b2 V7 b3 I
 m41 ii6 b2 I64 b3 V
 m42 I

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/3/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - 3: Menuetto
+Title: String Quartet in A Major - No.3: Menuetto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/4/analysis.txt
@@ -1,43 +1,47 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - No.4: Fuga a tre soggetti: Allegro
+Title: String Quartet in A Major - 4: Fuga a tre soggetti: Allegro
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
-Proofreader: Automated translation using music21 and Mark Gotham's code.
+Proofreader: Automated translation from **harm to RomanText
 
 Time Signature: 4/4
+
 m1 A: I b4 I
-m2 b4 vi
-m3 b4 IV
-m4 b3 V65
+m2 b2 V6 b4 vi
+m3 b2 iii6 b4 IV
+m4 b2 I6 b3 V65
 m5 I b4 V
-m6 b4 iii
+m6 b2 V6/V b4 iii
 m7 b2 V/V b4 I
-m8 b2 V6 b4 V/V
+m8 b2 V6 b3 vi b4 V/V
 m9 V b3 I6
-m10 iii
-m11 V6
-m12 iii6 b2 I64 b3 ii
-m13 I
+m10 iii b3 vi6
+m11 V6 b3 IV6
+m12 iii6 b2 I64 b3 ii b4 V
+m13 I b3 V6
+m14 b2 viio6/V b3 V
+m15 b2 V6/V b3 I6
+m16 b2 V64 b3 IV64 b4 V/V
 m17 V6 b3 I b4 I
-m18 b4 vi6
-m19 b4 ii65
+m18 b2 V6 b4 vi6
+m19 b2 V6 b4 ii65
 m20 I6 b3 ii7 b4 V64
-m21 I
-m22 I6 b2 IV b4 iii
-m23 V6/ii b2 ii b4 I
-m24 IV65 b2 viio b4 vi
+m21 I b3 viio6
+m22 I6 b2 IV b3 V43 b4 iii
+m23 V6/ii b2 ii b3 V65 b4 I
+m24 IV65 b2 viio b3 V43/vi b4 vi
 m25 Ger7/VI b3 V/VI
-m26 VI6
-m27 V6
-m28 IV6 b3 v7
-m29 IV b2 ii6 b3 iii
+m26 VI6 b2 V7/II b3 II b4 V7/V
+m27 V6 b2 V7 b3 I
+m28 IV6 b3 v7 b4 I64
+m29 IV b2 ii6 b3 iii b4 vi
 m30 ii b2 V7 b3 I
-m31 IV b3 v6
-m32 IV6 b2 viio b3 I64
-m33 ii6 b2 v b3 I6
-m34 None b2 iio/ii b3 None b4 VI6/ii
-m35 None b2 V6/ii b3 ii
+m31 IV b3 v6 b4 I
+m32 IV6 b2 viio b3 I64 b4 vi
+m33 ii6 b2 v b3 I6 b4 IV
+m34 b2 iio/ii b4 VI6/ii
+m35 b2 V6/ii b3 ii
 m36 V6/ii b2 V7/ii b3 ii b4.5 V7/V
-m37 V6 b3 I
+m37 V6 b2 V7 b3 I
 m38 V6 b2 V b3 ii
 m39 vi6 b2 vi b3 iii
 m40 V/iii b3 c#: i6 b4 i
@@ -45,37 +49,37 @@ m41 iv b3 iio
 m42 III b3 i
 m43 iio b3 V6
 m44 i6 b2 i b4 V6
-m45 i b2 VI6 b3 V6
-m46 VI b2 iv6 b3 v
-m47 f#: i
-m48 i6 b3 iio7
-m49 i b2 iv64 b4 III
-m50 VI b2 iio64 b4 V7/iv
+m45 i b2 VI6 b3 V6 b4 V65
+m46 VI b2 iv6 b3 v b4 V43/iv
+m47 f#: i b3 V
+m48 i6 b3 iio7 b4.5 v
+m49 i b2 iv64 b3 viio b4 III
+m50 VI b2 iio64 b3 v b4 V7/iv
 m51 b: i b3 V6
 m52 i b2 V/IV b3 E: I6
-m53 ii b3 I b4.5 vi6
-m54 viio b2 V43 b3 vi
-m55 V b3 IV
-m56 V/vi b2 vi64
+m53 ii b2 V65 b3 I b4.5 vi6
+m54 viio b2 V43 b3 vi b4 IV6
+m55 V b2 I b3 IV b4 ii6
+m56 V/vi b2 vi64 b3 iii
 m57 vi6 b2 vi
 m58 ii6 b2 ii
 m59 V6 b2 V
 m60 I6 b2 V/IV
 m61 A: I b2 I
-m62 V6 b3 vi b4 ii7
-m63 V b3 IV b4 viio65
-m64 I6 b3 V7
-m65 I
-m66 vi b3 V b4 I64
+m62 V6 b2 V b3 vi b4 ii7
+m63 V b2 iii b3 IV b4 viio65
+m64 I6 b2 I b3 V7
+m65 I b3 V
+m66 vi b2 ii7 b3 V b4 I64
 m67 IV b2 viio7 b3 I6 b4 vi6
 m68 ii b2 V65 b3 I b4.5 viio7/V
 m69 V b3 I
-m70 ii b3 I64 b4 IV6
-m71 V b3 vi6 b4 ii6
-m72 V7 b3 viio64/V
-m73 V b4 ii
-m74 V7 b2 I64 b4 V
-m75 I64 b4 V
+m70 ii b2 V b3 I64 b4 IV6
+m71 V b2 iii6 b3 vi6 b4 ii6
+m72 V7 b2 I64 b3 viio64/V
+m73 V b3 vi6 b4 ii
+m74 V7 b2 I64 b3 IV6 b4 V
+m75 I64 b3 ii7 b4 V
 m76 I6 b2 I
 m77 IV6 b2 IV b4 ii
 m78 V6 b2 V b3 I b4 vi
@@ -84,14 +88,14 @@ m80 I
 m81 V b3 vi b4 ii7
 m82 V b2.5 iii b3 IV b4 iio7
 m83 iii b2.5 I b3 IV64 b4 I6
-m84 V
-m85 V
-m86 vi
+m84 V b3 vi b4 ii7
+m85 V b2 iii6 b3 IV b4 viio7
+m86 vi b2 I6 b3 viio6 b3.5 I b4 ii6 b4.5 viio/V
 m87 V b3 I
 m88 V b3 I6
-m89 ii b2 V b4 IV64
-m90 V6 b2 iii b4 ii43
-m91 V7 b2 I b3 ii65
+m89 ii b2 V b3 I b4 IV64
+m90 V6 b2 iii b3 vi b4 ii43
+m91 V7 b2 I b3 ii65 b4 V
 m92 I b4 vi6
 m93 viio64 b3 I
 m94 V2 b3 I b4 V

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/4/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No6/4/analysis.txt
@@ -1,5 +1,5 @@
 Composer: Haydn, Franz Joseph
-Title: String Quartet in A Major - 4: Fuga a tre soggetti: Allegro
+Title: String Quartet in A Major - No.4: Fuga a tre soggetti: Allegro
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 


### PR DESCRIPTION
Generally, many annotations were omitted in the first translation because they were annotated in `part != parts[0]`.

This set should have more annotations (and all the previous ones preserved), plus annotations at the pickup measures, which are helpful for alignment.