### PR TITLE
specified slow or fast 3/8

### DIFF
--- a/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/3/analysis.txt
+++ b/Corpus/Etudes_and_Preludes/Bach,_Johann_Sebastian/The_Well-Tempered_Clavier_I/3/analysis.txt
@@ -3,7 +3,7 @@ Title: Prelude No.3
 Analyst: Mark Gotham, manually, through judicious automation, and in collaboration with colleagues and students at Cornell University
 Note: Please submit a pull request for anything inaccurate, or submit a separate analysis for an alternative reading.
 
-Time signature: 3/8 
+Time Signature: slow 3/8 
 
 m1 C#: I
 m2 ii7

--- a/Corpus/OpenScore-LiederCorpus/Chaminade,_Cécile/_/Berceuse/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Chaminade,_Cécile/_/Berceuse/analysis.txt
@@ -5,7 +5,7 @@ Proofreader: Mark Gotham
 Note: Based on 'Open Score' CC0 encoding at https://musescore.com/OpenScore-Lieder-Corpus
 
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 m1 Eb: I[add6]
 m2 V43
 m3-4 = m1-2

--- a/Corpus/OpenScore-LiederCorpus/Coleridge-Taylor,_Samuel/6_Sorrow_Songs,_Op.57/4_She_sat_and_sang_alway/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Coleridge-Taylor,_Samuel/6_Sorrow_Songs,_Op.57/4_She_sat_and_sang_alway/analysis.txt
@@ -4,7 +4,7 @@ Analyst: S. Reenan
 Proofreader: M. Gotham
 
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 
 Form: Verse 1

--- a/Corpus/OpenScore-LiederCorpus/Coleridge-Taylor,_Samuel/_/Oh,_the_Summer/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Coleridge-Taylor,_Samuel/_/Oh,_the_Summer/analysis.txt
@@ -2,7 +2,7 @@ Composer: S. Coleridge-Taylor
 Title: Oh, the Summer
 Analyst: Mark Gotham
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 
 Pedal: Ab m1 m11 b1
 

--- a/Corpus/OpenScore-LiederCorpus/Paradis,_Maria_Theresia_von/12_Lieder,_1786/05_Die_Tanne_(Sieh_Doris,_wie_vom_Mond_bestrahlt_)/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Paradis,_Maria_Theresia_von/12_Lieder,_1786/05_Die_Tanne_(Sieh_Doris,_wie_vom_Mond_bestrahlt_)/analysis.txt
@@ -5,7 +5,7 @@ Proofreader: Mark Gotham
 Note: Based on 'Open Score' CC0 encoding at https://musescore.com/OpenScore-Lieder-Corpus
 
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 m1 G: I
 m2 I
 m3 V b3 viio64/ii

--- a/Corpus/OpenScore-LiederCorpus/Reichardt,_Louise/Zwölf_Gesänge,_Op.3/04_Wachtelwacht/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Reichardt,_Louise/Zwölf_Gesänge,_Op.3/04_Wachtelwacht/analysis.txt
@@ -5,7 +5,7 @@ Note: Score taken from the 'Open Score' CC0 encoding at https://musescore.com/Op
 Note: Please submit a pull request for anything inaccurate, or submit a separate analysis for an alternative reading.
 
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 m1 F: I b3 V7
 m2 I
 m3 V7

--- a/Corpus/OpenScore-LiederCorpus/Schubert,_Franz/Op.59/3_Du_bist_die_Ruh/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Schubert,_Franz/Op.59/3_Du_bist_die_Ruh/analysis.txt
@@ -4,7 +4,7 @@ Analyst: Mark Gotham, manually, through judicious automation, and in collaborati
 Proofreader:
 Note: Please submit a pull request for anything inaccurate, or submit a separate analysis for an alternative reading.
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 
 m1 Eb: I
 m2 vi6

--- a/Corpus/OpenScore-LiederCorpus/Schubert,_Franz/Winterreise,_D.911/09_Irrlicht/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Schubert,_Franz/Winterreise,_D.911/09_Irrlicht/analysis.txt
@@ -3,7 +3,7 @@ Title: Winterreise, D.911 - 9: Irrlicht
 Analyst: Mark Gotham, manually, through judicious automation, and in collaboration with colleagues and students.
 Note: Please submit a pull request for anything inaccurate, or submit a separate analysis for an alternative reading.
 
-Time signature: 3/8
+Time Signature: slow 3/8
 
 m1 b: i b2 i64
 m2 iv b2 i

--- a/Corpus/OpenScore-LiederCorpus/Schumann,_Robert/Dichterliebe,_Op.48/09_Das_ist_ein_Flöten_und_Geigen/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Schumann,_Robert/Dichterliebe,_Op.48/09_Das_ist_ein_Flöten_und_Geigen/analysis.txt
@@ -3,7 +3,7 @@ Title: Dichterliebe, Op.48 - 9: Das ist ein Flöten und Geigen
 Analyst: Mark Gotham, manually, through judicious automation, and in collaboration with colleagues and students.
 Note: Please submit a pull request for anything inaccurate, or submit a separate analysis for an alternative reading.
 
-Time signature: 3/8
+Time Signature: slow 3/8
 
 Form: Verse 1
 

--- a/Corpus/OpenScore-LiederCorpus/Schumann,_Robert/Frauenliebe_und_Leben,_Op.42/3_Ich_kann’s_nicht_fassen/analysis.txt
+++ b/Corpus/OpenScore-LiederCorpus/Schumann,_Robert/Frauenliebe_und_Leben,_Op.42/3_Ich_kann’s_nicht_fassen/analysis.txt
@@ -3,7 +3,7 @@ Title: Frauenliebe und Leben - 3: Ich kann's nicht fassen, nicht glauben
 Analyst: Mark Gotham, manually, through judicious automation, and in collaboration with colleagues and students.
 Note: Please submit a pull request for anything inaccurate, or submit a separate analysis for an alternative reading.
 
-Time signature: 3/8
+Time Signature: slow 3/8
 
 m0 b3 c: V
 m1 c: i

--- a/Corpus/Piano_Sonatas/Beethoven,_Ludwig_van/Op026/1/analysis.txt
+++ b/Corpus/Piano_Sonatas/Beethoven,_Ludwig_van/Op026/1/analysis.txt
@@ -3,7 +3,7 @@ Title: Piano Sonata 12, Op.26, Movement 1
 Analyst: Tsung-Ping Chen and Li Su, BPS dataset (ISMIR 2018), see https://github.com/Tsung-Ping/functional-harmony
 Proof-reader: Automated conversion and manual proof-reading by Mark Gotham.
 
-Time signature: 3/8
+Time Signature: slow 3/8
 
 Form: Theme
 m0 b3 Ab: I

--- a/Corpus/Piano_Sonatas/Beethoven,_Ludwig_van/Op026/1/analysis_BPS.txt
+++ b/Corpus/Piano_Sonatas/Beethoven,_Ludwig_van/Op026/1/analysis_BPS.txt
@@ -3,7 +3,7 @@ Title: Piano Sonata 12, Op.26, Movement 1
 Analyst: Tsung-Ping Chen and Li Su, BPS dataset (ISMIR 2018), see https://github.com/Tsung-Ping/functional-harmony
 Proof-reader: Automated conversion and manual proof-reading by Mark Gotham.
 
-Time signature: 3/8
+Time Signature: fast 3/8
 
 Form: Theme
 m0 b3 Ab: I

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op130/4/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op130/4/analysis.txt
@@ -3,7 +3,7 @@ Piece: Op. 130, Quartet No. 13
 Analyst: Neuwirth et al. ABC dataset. See https://github.com/DCMLab/ABC
 Proof-reader: various, work in progress.
 Movement: 4
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m1 G: I
 m2 vi

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op132/3/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op132/3/analysis.txt
@@ -37,7 +37,7 @@ m29 I b3 IV
 m30 ii b3 V
 m31 V/ii b3 D: V
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 m32 I
 m33 V6
 m34 vi7
@@ -124,7 +124,7 @@ m113 I b3 vi6 b4 IV
 m114 ii b3 V
 m115 D: V b3 V7
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 m116 I
 m117 V6
 m118 vi

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op18_No4/2/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op18_No4/2/analysis.txt
@@ -3,7 +3,7 @@ Piece: Op. 18 No. 4, Quartet No. 4
 Analyst: Neuwirth et al. ABC dataset. See https://github.com/DCMLab/ABC
 Proof-reader: various, work in progress.
 Movement: 2
-Time Signature: 3/8
+Time Signature: slow 3/8
 
 m1 C: V
 m2 I

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op18_No6/4/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op18_No6/4/analysis.txt
@@ -48,7 +48,7 @@ m42 bb: viio7
 m43 i b2 ii/o6/5 b2.5 ii/o4/3
 m44 i6/4 b2 V ||
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 m46 I b1.33 i6/4
 m47 V6/5 b1.33 V7
 m48 V6 b1.33 V4/3/V b1.67 V7
@@ -200,7 +200,7 @@ m203 #i6/4
 m204 a: viio2
 m205 V7
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 m206 i b1.33 i6/4
 m207 V6/5 b1.33 V7
 m208 V6 b1.33 ii4/3 b1.67 V7
@@ -210,7 +210,7 @@ Time Signature: 2/4
 m211 i
 m212 G: V6/5 b2.75 I
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 m213 b1.33 I6/4
 m214 V6/5 b1.33 V7
 m215 V6/5 b1.67 V7

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op59_No1/2/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op59_No1/2/analysis.txt
@@ -3,7 +3,7 @@ Piece: Op. 59 No. 1, Quartet No. 7
 Analyst: Neuwirth et al. ABC dataset. See https://github.com/DCMLab/ABC
 Proof-reader: various, work in progress.
 Movement: 2
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m1 Bb: I
 m5 V

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op74/2/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op74/2/analysis.txt
@@ -3,7 +3,7 @@ Piece: Op. 74, Quartet No. 10
 Analyst: Neuwirth et al. ABC dataset. See https://github.com/DCMLab/ABC
 Proof-reader: various, work in progress.
 Movement: 2
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m1 Ab: I
 m3 V/V b1.33 viio7 b1.67 I

--- a/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/3/analysis.txt
+++ b/Corpus/Quartets/Haydn,_Franz_Joseph/Op20_No1/3/analysis.txt
@@ -3,7 +3,7 @@ Title: String Quartet in E-flat Major - No.3: Affettuoso e sostenuto
 Analyst: Néstor Nápoles López, https://doi.org/10.5281/zenodo.1095617
 Proofreader: Automated translation from **harm to RomanText
 
-Time Signature: 3/8
+Time Signature: slow 3/8
 
 m1 Ab: I
 m2 IV64

--- a/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_65/analysis_A.txt
+++ b/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_65/analysis_A.txt
@@ -340,7 +340,7 @@ m242 I
 m243 IV
 m244 I
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m245 I b1.67 viio7/vi
 m246 vi b1.67 viio65/ii
@@ -356,7 +356,7 @@ m250 V
 m251 I b2 IV6 b2.5 V43/V
 m252 V
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m253 I
 m254 V42
@@ -372,7 +372,7 @@ m258 I
 m259 V7
 m260 I
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m261 V42
 m262 I6
@@ -388,7 +388,7 @@ m266 I
 m267 V7
 m268 I
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m269 V42
 m270 I6

--- a/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_65/analysis_B.txt
+++ b/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_65/analysis_B.txt
@@ -340,7 +340,7 @@ m242 I
 m243 IV
 m244 I
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m245 I b1.67 V7/vi
 m246 vi b1.67 viio65/ii
@@ -356,7 +356,7 @@ m250 V
 m251 I b2 IV6 b2.5 V43/V
 m252 V
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m253 I
 m254 V42
@@ -372,7 +372,7 @@ m258 I
 m259 V7
 m260 I
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m261 V42
 m262 I6
@@ -388,7 +388,7 @@ m266 I
 m267 V7
 m268 I
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m269 V42
 m270 I6

--- a/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_73/analysis_A.txt
+++ b/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_73/analysis_A.txt
@@ -239,7 +239,7 @@ m166 I b4 V ||
 
 Form: Variation 10 a
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m167 I
 m168 I

--- a/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_73/analysis_B.txt
+++ b/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_73/analysis_B.txt
@@ -239,7 +239,7 @@ m166 I b4 V ||
 
 Form: Variation 10 a
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m167 I
 m168 I

--- a/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_76/analysis_A.txt
+++ b/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_76/analysis_A.txt
@@ -5,7 +5,7 @@ Proof-reader: Automated conversion and checks by Mark Gotham.
 
 Form: Theme a
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m1 F: I
 m2 V
@@ -401,7 +401,7 @@ m306 V ||
 
 Form: Variation 8 h
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m307 I6
 m308 IV b1.67 ii6

--- a/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_76/analysis_B.txt
+++ b/Corpus/Variations_and_Grounds/Beethoven,_Ludwig_van/_/WoO_76/analysis_B.txt
@@ -5,7 +5,7 @@ Proof-reader: Automated conversion and checks by Mark Gotham.
 
 Form: Theme a
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m1 F: I
 m2 V
@@ -402,7 +402,7 @@ m306 V ||
 
 Form: Variation 8 h
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m307 I6
 m308 ii6

--- a/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K398/analysis_A.txt
+++ b/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K398/analysis_A.txt
@@ -255,7 +255,7 @@ Time Signature: 4/2
 
 m163 V7 b2 V7
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m164 V7
 

--- a/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K398/analysis_B.txt
+++ b/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K398/analysis_B.txt
@@ -253,7 +253,7 @@ Time Signature: 4/2
 
 m163 V7 b2 V7
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m164 V7
 

--- a/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K455/analysis_A.txt
+++ b/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K455/analysis_A.txt
@@ -349,7 +349,7 @@ m210 I ||
 
 Form: Variation 10 a
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m211 I
 m212 V6
@@ -426,7 +426,7 @@ m265 V7
 m266 V7
 m267 V7
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m268 V
 m269 V7

--- a/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K455/analysis_B.txt
+++ b/Corpus/Variations_and_Grounds/Mozart,_Wolfgang_Amadeus/_/K455/analysis_B.txt
@@ -349,7 +349,7 @@ m210 I ||
 
 Form: Variation 10 a
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m211 I
 m212 V6
@@ -426,7 +426,7 @@ m265 V7
 m266 V7
 m267 V7
 
-Time Signature: 3/8
+Time Signature: fast 3/8
 
 m268 V
 m269 V7


### PR DESCRIPTION
Resolves #35 

I'm not sure why for certain files (e.g. Corpus/OpenScore-LiederCorpus/Chaminade,_Cécile/_/Berceuse/analysis.txt), github's comparison is showing many lines as having been changed (although they appear to be identical). The files in question appear to be identical in my text editor, other than the change to fast or slow 3/8.