### PR TITLE
Add an environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: WhenInRome
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.9
+  - music21
+  - numpy


### PR DESCRIPTION
Adding an environment.yml file simplifies the process of creating the virtual environment necessary to run the code. All is needed in order to prepare the environment is to run
```
conda env create -f environment.yml
```

In this specific case, there are two dependencies that I have not added:
- `AugmentedNet`, because that repo does not contain a setup.py file so conda doesn't know how to install it
- `tensorflow`, because it is used in the same module as AugmentedNet so it is useless unless the previous one is fixed

I think that adding setup.py to AugmentedNet should be a relatively easy and straightforward job, probably possible in an hour or so. Do you think that Néstor might appreciate us contributing to it?