### PR TITLE
Paths

### DIFF
--- a/Code/updates_and_checks.py
+++ b/Code/updates_and_checks.py
@@ -214,8 +214,8 @@ def process_corpus(corpus: str = 'OpenScore-LiederCorpus',
                                   combine=combine,
                                   slices=slices,
                                   feedback=feedback)
-            except:
-                print(f'Error with: {pth}')
+            except Exception as e:
+                print(f'Error with: {pth}. {e}')
 
 
 # ------------------------------------------------------------------------------

--- a/Code/updates_and_checks.py
+++ b/Code/updates_and_checks.py
@@ -59,37 +59,24 @@ corpora = [
 
 # Get file lists
 
-def get_corpus_files(corpus: str = 'OpenScore-LiederCorpus',
-                     file_name: Optional[str] = '',
-                     name_end: Optional[str] = ''
+def get_corpus_files(corpus: str = '',
+                     file_name: Optional[str] = '*.*',
                      ) -> list:
     '''
-    Get and return paths to files matching conditions for either
-    the whole file name (file_name) or only the end (extension or otherwise).
-    If the entire file name is specified, end is ignored.
-    :param corpus: the sub-corpus to search over. Empty string ('') to run all corpora.
-    :param file_name: a full file name (optional)
-    :param name_end: the end of the file name (file extension or otherwise, optional)
+    Get and return paths to files matching conditions for the given file_name.
+    :param corpus: the sub-corpus to search over. Empty string ('') to run all corpora (default value).
+    :param file_name: select all files that are compliant with this file_name, using
+     the usual wildcard '*' to match patterns. Examples:
+      - *.mxl searches for all .mxl files
+      - slices* searches for all files starting with slices
+      - analysis_automatic.rntxt searches for all exact matches of that file name
     :return: list of file paths.
     '''
 
-    if corpus != '' and corpus not in corpora:
+    if corpus not in ['', *corpora]:
         raise ValueError(f"Invalid corpus: must be one of {corpora} or an empty string (for all)")
 
-    base_path = str(CORPUS_FOLDER / corpus)
-
-    paths = []
-
-    for dpath, dname, fname in os.walk(base_path):
-        for name in fname:
-            if file_name:
-                if name == file_name:
-                    paths.append(str(os.path.join(dpath, name)))
-            elif name_end:  # ignored if search on whole file name
-                if name.endswith(name_end):
-                    paths.append(str(os.path.join(dpath, name)))
-
-    return paths
+    return [str(x) for x in (CORPUS_FOLDER / corpus).rglob(file_name)]
 
 
 def get_analyses(corpus: str = 'OpenScore-LiederCorpus',

--- a/Code/updates_and_checks.py
+++ b/Code/updates_and_checks.py
@@ -34,7 +34,7 @@ import os
 import re
 import shutil
 
-from pathlib import PurePath, Path
+from pathlib import Path
 from typing import Optional, Union
 
 from . import romanUmpire
@@ -429,7 +429,7 @@ def convert_DCML_tsv_analyses(corpus: str = 'Quartets',
         new_dir = os.path.dirname(os.path.dirname(f))
         out_path = os.path.join(new_dir, 'analysis.txt')
         
-        path_parts = PurePath(os.path.realpath(new_dir)).parts
+        path_parts = Path(os.path.realpath(new_dir)).parts
         
         genre, composer, opus, movement = path_parts[-4:]
         genre = genre[:-1].replace('_', ' ')  # Cut plural 's'

--- a/Code/updates_and_checks.py
+++ b/Code/updates_and_checks.py
@@ -213,7 +213,8 @@ def process_corpus(corpus: str = 'OpenScore-LiederCorpus',
                                   pth,
                                   combine=combine,
                                   slices=slices,
-                                  feedback=feedback)
+                                  feedback=feedback,
+                                  overwrite=overwrite)
             except Exception as e:
                 print(f'Error with: {pth}. {e}')
 

--- a/Code/updates_and_checks.py
+++ b/Code/updates_and_checks.py
@@ -34,7 +34,7 @@ import os
 import re
 import shutil
 
-from pathlib import PurePath
+from pathlib import PurePath, Path
 from typing import Optional, Union
 
 from . import romanUmpire
@@ -127,8 +127,8 @@ def clear_the_decks(corpus: str = '',
             os.remove(f)
             
     for s in fileTypeToStay:
-        miscellany += get_corpus_files(corpus=corpus, file_name=g)
-    
+        miscellany += get_corpus_files(corpus=corpus, file_name=s)
+
     return miscellany
 
 
@@ -169,41 +169,26 @@ def process_one_score(path_to_score: str,
     stopping_message = 'file exists and overwrite set to False. Stopping'
 
     if combine:
-        if overwrite:
+        if overwrite or not os.path.exists(Path(write_path) / 'analysis_on_score.mxl'):
             t.writeScoreWithAnalysis(outPath=write_path,
                                      outFile='analysis_on_score')
         else:
-            hypothetical_path = os.path.join(path_to_score, 'analysis_on_score.mxl')
-            if os.path.exists(hypothetical_path):
-                print('analysis_on_score ' + stopping_message)
-            else:
-                t.writeScoreWithAnalysis(outPath=write_path,
-                                         outFile='analysis_on_score')
+            print('analysis_on_score ' + stopping_message)
 
     if slices:
         t.matchUp()  # Sic, necessary here and only here
-        if overwrite:
+        if overwrite or not os.path.exists(Path(write_path) / 'slices_with_analysis.tsv'):
             t.writeSlicesFromScore(outPath=write_path,
                                    outFile='slices_with_analysis')
         else:
-            hypothetical_path = os.path.join(path_to_score, 'slices_with_analysis.tsv')
-            if os.path.exists(hypothetical_path):
-                print('slices_with_analysis ' + stopping_message)
-            else:
-                t.writeSlicesFromScore(outPath=write_path,
-                                       outFile='slices_with_analysis')
+            print('slices_with_analysis ' + stopping_message)
 
     if feedback:
-        if overwrite:
+        if overwrite or not os.path.exists(Path(write_path) / 'feedback_on_analysis.txt'):
             t.printFeedback(outPath=write_path,
                             outFile='feedback_on_analysis')
         else:
-            hypothetical_path = os.path.join(path_to_score, 'feedback_on_analysis.txt')
-            if os.path.exists(hypothetical_path):
-                print('feedback_on_analysis ' + stopping_message)
-            else:
-                t.printFeedback(outPath=write_path,
-                                outFile='feedback_on_analysis')
+            print('feedback_on_analysis ' + stopping_message)
 
 
 def process_corpus(corpus: str = 'OpenScore-LiederCorpus',


### PR DESCRIPTION
Fix two bugs with paths:
1. In the first case, `process_one_score` was not checking if the score was present in the output folder but in an invalid path constructed by appending the output_name to the input_score_path. For example: `/Corpus/.../score.mxl/slices_with_analysis.tsv`. Also, the overwrite flag was not passed down from process_corpus so it was not possible to actually overwrite the files
2. In the second case, `clear_the_decks` was always returning an empty list even if there were files that were kept. This was due to a wrong variable.

I also simplified a few things in the paths. 

Also, the error messages when processing the corpus are now reported out.