### PR TITLE
Automatic release based on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Pack and release the dataset and repository
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on pushing new tags
+  push:
+    tags:
+      - "v*"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build_latex:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2.4.0
+      - name: Zip the Corpus folder
+        run: zip -r Corpus.zip Corpus/
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            Corpus.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v2.4.0
       - name: Zip the Corpus folder
-        run: zip -r Corpus.zip Corpus/
+        run: zip -r Corpus.zip Corpus/*
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build_latex:
+  build_release:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The idea of this gh-actions workflow is very simple:

Every time a new `tag` is created, the script will
- Pack the contents of the `Corpus` folder in a zip file
- Pack the full contents of the repository (minus version history)
- Create a release that will include those Zip files in the main `Releases` section of the repo

It is a very simple idea but I think very powerful and sustainable.

On the side of the developer, this is what needs to be done:
- Develop as usual (commit code/music, assess pull requests, etc.)
- Once a desirable state has been achieved on the repo, worthy of a new release, do the following

```bash
$ git tag vX.Y
$ git push origin --tags
```

And that's it. `vX.Y` of the dataset will be publicly available, and a `.zip` file for the repository (or only the Corpus) will be created and freely available to the public. 

If additional steps are necessary (e.g., also push the `Code` repository on its own zip file), the `.yml` script should be easily adaptable.