### PR TITLE
Fix m21 parse errors in Beethoven Quartets

### DIFF
--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op018_No3/4/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op018_No3/4/analysis.txt
@@ -110,7 +110,7 @@ m110 #viio7/vi
 m112 ii64
 m113 bVIId7
 m114a V65
-m116 b2.33 ii6 b2.33 ii6
+m116 b2.33 ii6
 m117a I6
 m118a viio6
 m120 I iiio6 b1.33 IV b2.33 ii6

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op018_No6/4/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op018_No6/4/analysis.txt
@@ -207,7 +207,7 @@ m211 G: V65 b2.25 I
 Time Signature: 3/8
 m212 b1.33 I64
 m213 V65 b1.33 V7
-m214 V65 b1.33 V7
+m214 V65 b1.67 V7
 m215 I
 m216 V7/IV
 m217 IV b1.33 Bb: ii
@@ -215,46 +215,46 @@ m218 ii2
 m219 V65
 m221 I b1.33 I64
 m222 V65 b1.33 V7
-m223 V6 b1.33 V43 b1.33 V7
-m224 I b1.33 V65/IV
-m225 IV b1.33 #viio6/vi b1.33 #viio/ii
-m226 ii b1.33 V6/vi b1.33 vi
-m227 ii6 b1.33 ii b1.33 ii6
+m223 V6 b1.33 V43 b1.67 V7
+m224 I b1.67 V65/IV
+m225 IV b1.33 #viio6/vi b1.67 #viio/ii
+m226 ii b1.33 V6/vi b1.67 vi
+m227 ii6 b1.33 ii b1.67 ii6
 m228 V
-m230 b1.33 V7
-m232 V43/IV b1.33 IV b1.33 V7/IV
-m233 IV b1.33 #viio6/vi b1.33 #viio/ii
-m234 ii b1.33 V6/vi b1.33 vi
-m235 ii6 b1.33 ii b1.33 V7
+m230 b1.67 V7
+m232 V43/IV b1.33 IV b1.67 V7/IV
+m233 IV b1.33 #viio6/vi b1.67 #viio/ii
+m234 ii b1.33 V6/vi b1.67 vi
+m235 ii6 b1.33 ii b1.67 V7
 m236 I
 m237 I
 m238 viio6
-m240 I6 b1.33 I
+m240 I6 b1.67 I
 m241 I6
-m242 ii6 b1.33 V65/V
-m243 V b1.33 #viio7/vi
-m244 vi b1.33 V65/IV
-m245 IV b1.17 V65/V b1.33 Cad64 b1.33 V7
+m242 ii6 b1.67 V65/V
+m243 V b1.67 #viio7/vi
+m244 vi b1.67 V65/IV
+m245 IV b1.17 V65/V b1.33 Cad64 b1.67 V7
 m246 I
-m247 vi b1.33 I64
+m247 vi b1.67 I64
 m248 viio6
-m249 V65 b1.33 V2
+m249 V65 b1.67 V2
 m250 I6
-m251 I b1.33 V2/IV b1.33 IV6
+m251 I b1.33 V2/IV b1.67 IV6
 m252 IV
-m253 b1.33 ii6 b1.33 V65/V
-m254 V b1.33 #viio7/vi
-m255 vi b1.33 V2/IV b1.33 V65/IV
+m253 b1.33 ii6 b1.67 V65/V
+m254 V b1.67 #viio7/vi
+m255 vi b1.33 V2/IV b1.67 V65/IV
 m256 IV
 m257 V65/V
 m258 Cad64
 m259 V7
-m260 I b1.33 I64
-m261 I b1.33 I64
-m262 V43 b1.33 V7
-m263 V43 b1.33 V7
+m260 I b1.67 I64
+m261 I b1.67 I64
+m262 V43 b1.67 V7
+m263 V43 b1.67 V7
 m264 I
-m266 V65 b1.33 V7
+m266 V65 b1.67 V7
 m267 V7
 m269 V2
 m270 V7
@@ -265,17 +265,17 @@ m276 I64
 m277 V7
 m279 I
 m280 V2/IV
-m281 IV6 b1.33 IV
-m282 I6 b1.33 ii6 b1.33 V6/V
-m283 V7 b1.33 V6
-m284 I b1.33 V2/IV
-m285 IV6 b1.33 IV
-m286 I6 b1.33 ii6 b1.33 V6/V
-m287 V b1.33 IV6 b1.33 V6
-m288 I b1.33 V2/IV
-m289 IV6 b1.33 V7 b1.33 IV
-m290 I6 b1.33 ii6 b1.33 V6/V
-m291 V7 b1.33 vi7 b1.33 V6
+m281 IV6 b1.67 IV
+m282 I6 b1.33 ii6 b1.67 V6/V
+m283 V7 b1.67 V6
+m284 I b1.67 V2/IV
+m285 IV6 b1.67 IV
+m286 I6 b1.33 ii6 b1.67 V6/V
+m287 V b1.33 IV6 b1.67 V6
+m288 I b1.67 V2/IV
+m289 IV6 b1.33 V7 b1.67 IV
+m290 I6 b1.33 ii6 b1.67 V6/V
+m291 V7 b1.33 vi7 b1.67 V6
 m292 I
 m293 V
 m294 I

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op059_No2/1/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op059_No2/1/analysis.txt
@@ -68,8 +68,9 @@ m66 V7
 m67 Cad64
 m68 V7
 m69a I b2 V7
-m70a e: i Eb: I b2 e: V6 b2 Eb: V6
-m71a iii b2 V43 b2.67 V7
+m70a e: i b2 V6
+m69b i Eb: iii b2 V43 b2.67 V7 
+m70b I b2 V6
 m72 I b2 V6
 m74 i b2 b: #viio6
 m76 i b2 V6

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op059_No2/3/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op059_No2/3/analysis.txt
@@ -10,8 +10,10 @@ m3 V7
 m4 i[no3][add9][add4] b3 i
 m6 viio/VII
 m7 V7/VII
-m8a VII[add#7] VII[add#7] b2 VII b2 VII b3 V7
-m9a i VII6 b2 G: viio7
+m8a VII[add#7] b2 VII b3 V7
+m9a i
+m8b VII[add#7] b2 VII
+m9a VII6 b2 G: viio7
 m10 I[no3][add4] b2 I[no3][add#2] b3 I
 m11 #viio7/ii
 m12 ii[no3][add9][add4] b3 ii
@@ -44,12 +46,15 @@ m45 b3 viio64
 m46 b3 i6
 m47 viio64 b3 i6
 m48 b2 V7
-m49 i b3 i
-m50a i V
-m51a V i b2 E: I b3 V
-m52a e: i E: I b2 I6
-m53a e: viiø7/III b2 viio7/III b2 E: V2 b3 I6
-m54 V43 b2 I b3 V
+m49 b2 i
+Note: this is m50 but there is a measure omitted in the TSV, so marking it as var1 will keep measure numbering consistent
+m49var1 i
+m50 V
+m51 i E: I b3 V
+Note: this is the first ending's last measure
+m51var1 e: viiø7/III b2 viio7/III
+m52 I b2 I6
+m53 
 m55 I
 m56 V43
 m57 I b2 V6 b3 V65/V

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op059_No3/1/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op059_No3/1/analysis.txt
@@ -23,7 +23,7 @@ m19 iiø7
 m20 viio65
 m21 iv64
 m22 viio7
-m29 V65 b4 I
+m29 V65 b3 I
 Time Signature: 4/4
 m30 V7
 m32 b3 V7[add9]

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op095/4/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op095/4/analysis.txt
@@ -12,8 +12,8 @@ m4 Cad64 b1.88 viio43/V b2 V[no5][no3][add7][add6][add4] b2.25 V b2.5 viio7/V
 m5 b1.5 V6 b2 VI6[no8][add7] b2.25 VI6 b2.5 V7[add9]
 m6 V43 b1.5 V6 b2 VI6[no8][add7] b2.25 VI6 b2.5 V7[add9]
 m7 V43
-m9 b2.5 V43 b2.33 i b2.67 V6
 Time Signature: 6/8
+m9 b2.33 i b2.67 V6
 m10 i
 m12 iv b2 i
 m13 iv b2 i

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op127/2/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op127/2/analysis.txt
@@ -1,3 +1,4 @@
+
 Composer: Beethoven, Ludwig van
 Title: n12op127_02
 Analyst: DCML members and contributors. Licence CC-BY-NC-SA. This file is automatically converted from https://raw.githubusercontent.com/DCMLab/ABC/harmonies/n12op127_02.tsv
@@ -40,7 +41,7 @@ m34 I6[no3][add4] b1.67 I6 b2 I64 b3 V43 b3.67 I b4 V2/IV b4.67 ii64 b4.83 iiio6
 m35 V43/IV b1.33 IV b1.83 I6 b2.33 V7/V b2.83 viio2 b3.33 I64 b4.33 ii65 b4.83 f: Ger6
 m36 b1.33 Cad64 b1.67 VI b2.33 Ab: V7 b3 Cad64 b4 #io64 b4.33 V7
 m37 iiio b2 IV b2.67 iv b3 Cad64 b4 V7 b4.83 #viio7/vi
-m38 V43/V b2 V65 b2.67 V b3 I b3 V2
+m38 V43/V b2 V65 b3 V b3.5 I b4.5 V2
 Time Signature: 4/4
 m39 I6 b2 I
 m40 V43
@@ -89,11 +90,11 @@ m80 Cad64 b2 viio43/V b3 V b4.33 V7
 m81 I64
 m82 V7
 m83 I64 b1.33 V6/vi b1.67 vi b2.33 V43/vi b2.67 vi6 b3 V6/ii b3.33 V[no1][add2] b3.67 V b4 Eb: V7
-m84 V2 b3 I b3.33 I b3.67 Ab: vi7 b4 vi b4.33 V6 b4.33 I
+m84 V2 b3 I b3.33 I b3.67 Ab: vi7 b4 vi b4.33 V6 b4.67 I
 m85 V7 b2 V65 b3 V7[no3][add4] b3.83 V7 b4 V7[no3][add4] b4.5 V7
 m86 V2/ii b1.33 V7/ii
 m87 V43/V b4.33 V65/V
-m88 Cad64 b2 V7 b3 Cad64 b3.33 V6 b3.67 vi65 b4 #vio65 b4.33 V43 b4.33 I64
+m88 Cad64 b2 V7 b3 Cad64 b3.33 V6 b3.67 vi65 b4 #vio65 b4.33 V43 b4.67 I64
 m89 #vi65 b1.33 V7 b3 vi65
 m90 V43 b1.67 #viio65/ii b3 v43 b4 #vo43 b4.33 vi43
 m91 V65/V b3 V43/V b4 V2/V b4.33 V43
@@ -130,5 +131,5 @@ m121 iv64 b2 ii65 b3 Cad64 b4 V7
 m122 iv6 b2 ii43 b3 iv6
 m123 #V b2 V65/#V b3 #V
 m124 Cad64 b2 V7 b3 Cad64 b4 V7
-m125 viio b1.5 I b1.67 i64 b1.83 V6/vi b2 vi b2.33 #viio6/ii b2.5 ii6 b2.67 IV6 b3 V43 b3.5 I b3.67 IV6 b4 V43 b4.5 I b4.33 vi7
+m125 viio b1.5 I b1.67 i64 b1.83 V6/vi b2 vi b2.33 #viio6/ii b2.5 ii6 b2.67 IV6 b3 V43 b3.5 I b3.67 IV6 b4 V43 b4.5 I b4.67 vi7
 m126 V43 b3.5 I

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op131/4/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op131/4/analysis.txt
@@ -190,41 +190,41 @@ m184 I b2 V
 m185a I b2 V
 m185b I b2 V65
 Time Signature: 9/4
-m186 b1.33 I b2.33 V65 b2.67 I b3.33 V65 b3.33 I
-m187 b1.33 V65 b2.33 #viio7/vii b2.67 V65 b3.33 #viio7/vii b3.33 V65
-m188 b1.33 V2 b2.33 #viio65/ii b2.67 V2 b3.33 #viio65/ii b3.33 V2
-m189 b1.33 I6 b2.33 #vio7/iii b2.67 I6 b3.33 #viio7/iii b3.33 I6
+m186 b1.33 I b2.33 V65 b2.67 I b3.33 V65 b3.67 I
+m187 b1.33 V65 b2.33 #viio7/vii b2.67 V65 b3.33 #viio7/vii b3.67 V65
+m188 b1.33 V2 b2.33 #viio65/ii b2.67 V2 b3.33 #viio65/ii b3.67 V2
+m189 b1.33 I6 b2.33 #vio7/iii b2.67 I6 b3.33 #viio7/iii b3.67 I6
 m190 b1.33 V2/IV
 m191 viio7/V
-m192 V65 b2 I b3.33 ii6 b3.33 viiø7/V
-m193 Cad64 b1.33 V b1.67 V[no3][no1][add4][add2][add#7] b2 V b3 V7 b3.33 IV b3.33 V43
-m194 I b1.33 I64 b2 I b2.33 V7 b2.67 I b3.33 V7 b3.33 I
-m195 b1.33 V7 b2.33 #viio7/vii b2.67 V7 b3.33 #viio7/vii b3.33 V7
-m196 V[no5][add6] b1.33 V b2 V2 b2.33 V[no5][add6] b2.67 V b3.33 V[no5][add6] b3.33 V
-m197 b1.33 I64 b2 I6 b2.33 #viio7/iii b2.67 I b3.33 #viio7/iii b3.33 I
+m192 V65 b2 I b3.33 ii6 b3.67 viiø7/V
+m193 Cad64 b1.33 V b1.67 V[no3][no1][add4][add2][add#7] b2 V b3 V7 b3.33 IV b3.67 V43
+m194 I b1.33 I64 b2 I b2.33 V7 b2.67 I b3.33 V7 b3.67 I
+m195 b1.33 V7 b2.33 #viio7/vii b2.67 V7 b3.33 #viio7/vii b3.67 V7
+m196 V[no5][add6] b1.33 V b2 V2 b2.33 V[no5][add6] b2.67 V b3.33 V[no5][add6] b3.67 V
+m197 b1.33 I64 b2 I6 b2.33 #viio7/iii b2.67 I b3.33 #viio7/iii b3.67 I
 m198 V2/IV
 m199 viio6/V
-m200 V65 b2 I b3.33 ii6 b3.33 viiø7
-m201 b1.33 V b1.67 I6 b2 V64 b2.33 I64 b2.67 V43[no1][add2]/V b3 V b3.33 V43/V b3.33 V65
+m200 V65 b2 I b3.33 ii6 b3.67 viiø7
+m201 b1.33 V b1.67 I6 b2 V64 b2.33 I64 b2.67 V43[no1][add2]/V b3 V b3.33 V43/V b3.67 V65
 m202 b2 V43 b3 IV+64
-m203 IV+6 b2.33 V65 b3.33 I b3.33 V7
+m203 IV+6 b2.33 V65 b3.33 I b3.67 V7
 m204 V65 b1.33 I b1.67 V65/IV b2 V2/IV b3 V65/IV
-m205 V65/IV b2 V2/IV b2.33 #viio2/ii b3.33 ii64 b3.33 V7/ii
+m205 V65/IV b2 V2/IV b2.33 #viio2/ii b3.33 ii64 b3.67 V7/ii
 m206 b1.67 ii b2.67 Cad64/vi b3.33 V7/vi
 m207 IV[no5][no3][no1][add6][add4][add2] b1.33 IV b2.33 IV b2.67 V7/V
 m208 IV b1.67 ii65 b2 V[no5][no3][add7][add6][add4] b2.33 Cad64 b2.67 iv64/V b3 viio7/V b3.33 V7
-m209 b1.33 I b2.67 V7/V b3 V64 b3.33 V7/V b3.33 V7
+m209 b1.33 I b2.67 V7/V b3 V64 b3.33 V7/V b3.67 V7
 m210 b2 V65 b3 V[no3][add4]/ii b3.33 V/ii
-m211 b1.33 V+/ii b1.67 V7 b2 V7 b2.33 I b2.67 I64 b3 I b3.33 V65 b3.33 V7
+m211 b1.33 V+/ii b1.67 V7 b2 V7 b2.33 I b2.67 I64 b3 I b3.33 V65 b3.67 V7
 m212 V65 b1.33 I64 b1.67 I64
 m213 V7/ii b2.33 ii b2.67 ii64 b3 ii64 b3.33 V7/ii
-m214 V65/ii b1.33 ii b2.67 V[no5][no3][add7][add6][add4]/vi b3.33 V/vi b3.33 #viio65/vi
+m214 V65/ii b1.33 ii b2.67 V[no5][no3][add7][add6][add4]/vi b3.33 V/vi b3.67 #viio65/vi
 m215 b1.33 vi b1.67 vi2 b2 vi b3.33 V7/V
-m216 vi b1.33 IV6 b1.67 ii65 b2 I64[no8][add7] b2.33 I64 b2.67 I64 b3 viio65/V b3.33 V65 b3.33 V7
-m217 V65 b1.33 I b1.67 V7/IV b2 IV b2.33 v b2.67 IV64 b3 V65[no3][add4] b3.33 V65 b3.33 I
-m218 I6 b1.67 V7/IV b2 IV6 b2.67 IV64 b3 Cad64 b3.33 V2 b3.33 I
+m216 vi b1.33 IV6 b1.67 ii65 b2 I64[no8][add7] b2.33 I64 b2.67 I64 b3 viio65/V b3.33 V65 b3.67 V7
+m217 V65 b1.33 I b1.67 V7/IV b2 IV b2.33 v b2.67 IV64 b3 V65[no3][add4] b3.33 V65 b3.67 I
+m218 I6 b1.67 V7/IV b2 IV6 b2.67 IV64 b3 Cad64 b3.33 V2 b3.67 I
 m219 V65/V
-m220 V7[no3][add4] b3.33 V2 b3.33 V43
+m220 V7[no3][add4] b3.33 V2 b3.67 V43
 m221 V65 b2 V7
 m222 b2 V43[no3][add4]/IV b2.33 V43/IV b2.67 V65/IV b3 V7/IV b3.33 V2/IV
 m223 V65/IV

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op132/3/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op132/3/analysis.txt
@@ -84,13 +84,13 @@ m75 b1.17 I6 b1.33 I6 b1.5 I+ b1.67 viiø7[no3][add4]/V b1.83 viiø7/V
 m76 V[no5][no3][add6][add4][add2] b1.33 Cad64 b1.67 V7
 m77 V[no5][no3][add9][add6][add4] b1.33 I b1.67 viio6
 m78 I6 b1.33 viio7/V b1.67 V7
-m79 I b1.33 I b1.5 V2/IV b1.67 IV6
+m79 I b1.5 V2/IV b1.67 IV6
 m80 Cad64 b1.33 viio7/V b1.67 viio6
 m81 I[add9][add7] b1.17 I
 m82 b1.67 C: I6
 m83 b1.67 IV
-m85 I b1.67 IV6 b3 I b4 I6
 Time Signature: 4/4
+m85 I b1.67 IV6 b3 I b4 I6
 m86 I64 b2 IV6 b3 IV
 m87 IV6 b3 I
 m88 ii[no3][add4] b2 ii b3 I
@@ -174,8 +174,8 @@ m164 I64 b1.33 viio7/V b1.67 viio6
 m165 I[add9] b1.33 I
 m166 b1.67 C: I6
 m167 b1.67 IV
-m169 I b1.67 vi b3 I b4 IV6
 Time Signature: 4/4
+m169 I b2 vi b3 I b4 IV6
 m170 I64 b1.5 I b2 IV6 b3 IV6[add9] b4 IV
 m171 IV[add9] b1.5 IV b3 I
 m172 I[add9] b3 I[no5][add6] b3.5 I

--- a/Corpus/Quartets/Beethoven,_Ludwig_van/Op135/2/analysis.txt
+++ b/Corpus/Quartets/Beethoven,_Ludwig_van/Op135/2/analysis.txt
@@ -188,5 +188,8 @@ m262 I b2 V43 b3 I6
 m263 V7 b2 IV6 b3 viio
 m264 I b2 V43 b3 I6
 m265 V7 b2 IV6 b3 viio
-m266a I I b2 V2/IV b2 I
+m266a I b2 V42/IV
+m266b I
+Note: just making sure the parser picks up the I even if it misreads from the first ending
+m267 I
 m272 I


### PR DESCRIPTION
Patch the analysis.txt files for the complete Beethoven quartets so that they match the score AND parse in music21.

The changes were about 50% systematic parser errors -- mostly relating to beat 3 (1.67) in 3/8 [a notoriously difficult meter in general and in music21 and other software] and the last 8th beat in 9/8 and 12/8 as well.  These could be fixed in a later converter improvement, such as for future repertories.

About 25% are errors relating to weird things that Beethoven does around section breaks and repeat signs such as mid-measure time signature changes, repeat bars that don't line up between 1 and 2 (or with pickups, etc.)

About 25% appear to my untrained eyes errors in the tsv files (esp Op59 no. 2, movements 1 and 3)  also usually around these weird changes.

With these changes, every Beethoven quartet analysis.txt parses in music21.  :-)

Thanks for putting this repo together.  Wow, amazing.  Thanks ABC also!