### PR TITLE
Make Corelli RNText parsable

### DIFF
--- a/Corpus/Chamber_Other/Corelli,_Arcangelo/Op1No07/3/analysis.txt
+++ b/Corpus/Chamber_Other/Corelli,_Arcangelo/Op1No07/3/analysis.txt
@@ -41,7 +41,7 @@ m34 I b1.67 viio6/V b2 V
 m35 IV6[no1][add2] b1.67 IV6 b2 V65
 m36 I[no3][add4] b1.67 I b2 a: V
 m37 IV6[no1][add2] b1.67 IV6 b2 V65
-m38 i[no3][add4] i[no3][add4] b1.67 i b1.67 i b2 i6 b2 III
+m38 i[no3][add4] b1.67 i b2 i6
 m39 ii[no5][add6] b1.67 iv7 b2 V[no3][add4] b2.67 V
 m40 i b2 C: IV6 b2.67 iii6
 m41 ii6 b1.67 I6 b2 IV6 b2.67 iii6

--- a/Corpus/Chamber_Other/Corelli,_Arcangelo/Op1No09/4/analysis.txt
+++ b/Corpus/Chamber_Other/Corelli,_Arcangelo/Op1No09/4/analysis.txt
@@ -33,7 +33,7 @@ m41 I
 m49 V
 m50 
 Time Signature: 4/4
-m51 b2 I6 b3 IV[add9] b3 IV6
-m52 V65 b2 I b3 IVM65 b3 viio
-m53 I[add9] b2 i b2.5 IVd7 b3 V[no3][add4] b3 V
+m51 b2 I6 b3 IV[add9] b4 IV6
+m52 V65 b2 I b3 IV65 b4 viio
+m53 I[add9] b2 i b2.5 IVd7 b3 V[no3][add4] b4 V
 m54 I

--- a/Corpus/Chamber_Other/Corelli,_Arcangelo/Op3No03/2/analysis.txt
+++ b/Corpus/Chamber_Other/Corelli,_Arcangelo/Op3No03/2/analysis.txt
@@ -27,9 +27,9 @@ m20 I
 m22 IV
 m23 ii65
 m24 V b2 V[no5][add6] b3 I6
-m25 IV b3 ii b3 IV[no5][add6]
-m26 V b3 iii b3 V[no5][add6]
-m27 vi b3 IV b3 vi[no5][addb6]
+m25 IV b3 ii
+m26 V b3 iii
+m27 vi b3 IV
 m28 V b2 I b2.5 I6 b3 IV
 m29 I[no3][add4] b1.5 I b2 V[no3][add4] b3.5 V
 m30 I b3 I6/V

--- a/Corpus/Chamber_Other/Corelli,_Arcangelo/Op3No03/4/analysis.txt
+++ b/Corpus/Chamber_Other/Corelli,_Arcangelo/Op3No03/4/analysis.txt
@@ -5,29 +5,29 @@ Proofreader: Please refer to that source repository for full details.
 
 Time Signature: 6/4
 m1 Bb: I b2 V6
-m2 IV6[no1][add2] b1.67 viio b1.67 IV6 b2 I b2.33 V[no3][add4] b2.67 V
+m2 IV6[no1][add2] b1.67 viio b2 I b2.33 V[no3][add4] b2.67 V
 m3 I b2 V6 b2.33 V
 m4 F: ii2 b1.33 V6 b2 iv b2.33 IV b2.67 viio6
-m5 I b1.33 V[no3][add4] b2 I b2 V b2.67 Bb: V
+m5 I b1.33 V[no3][add4] b2 I b2.67 Bb: V
 m6 IV6[no1][add2] b1.33 IV6 b1.67 viio b2 I[no3][add4] b2.33 I b2.67 iv6
 m7 ii7 b1.33 V7 b2 vi[add9] b2.67 ii6
 m8 I6 b1.33 viio6 b2 I
 m9 V6 b2 vi7 b2.33 V7/V
-m10 V b1.67 iii b1.67 iii6 b2 ii6[no1][add2] b2.33 ii6 b2.67 ii
+m10 V b1.67 iii b2 ii6[no1][add2] b2.33 ii6 b2.67 ii
 m11 I6[no1][add2] b1.33 I6 b1.67 vi b2 ii7 b2.33 viio6 b2.67 V7
 m12 eb: i6[no1][add2] b1.33 i6 b1.67 VIM7 b2 iio7 b2.33 #viio6 b2.67 V7
 m13 i b1.33 VI6 b1.67 VI b2 v6[no1][add2] b2.33 v6 b2.67 v
 m14 iv6[no1][add2] b1.33 iv6 b1.67 iv b2 V7 b2.67 iv7
 m15 b1.33 V[no3][add4] b1.83 V b2 i
-m16 v6 b2 VI b2 iv6
+m16 v6 b2 iv6
 m17 v[no3][add4] b1.33 v b2 Bb: IV[no1][add2] b2.33 IV6 b2.67 viio
 m18 I[no3][add4] b1.33 I b2 ii7 b2.33 V7 b2.67 V
 m19 IM7 b1.33 vi6 b1.67 IV b2 viiø7 b2.33 V6 b2.67 iii
 m20 vi7 b1.33 IV6 b1.67 ii b2 V7 b2.33 iii6 b2.67 I
-m21 IV b1.33 viio64 b1.67 I b2 V[no3][add4] b2 V
+m21 IV b1.33 viio64 b1.67 I b2 V
 m22 I b2 V b2.67 V7
-m23 I[no3][add4] I b1.67 F: IV b2 V[no3][add4] b2 V
-m24 I[add9] I b2 vi6[no1][add2] b2 vi6
+m23 I[no3][add4] I b1.67 F: IV b2 V
+m24 I[add9] I b2 vi6
 m25 V7 b1.67 IVM7 b2.33 V[no3][add4] b2.83 V
 m26 I b2 V6
 m27 vi b2 V[no3][add4] b2.67 V
@@ -52,7 +52,7 @@ m45 i b1.33 Bb: I b2 V6
 m46 I b2 V6
 m47 I b1.67 I6 b2 IV b2.33 ii6
 m48 V7 b1.33 iii6 b2 IV6[no1][add2] b2.33 IV6
-m49 viiø7 b1.33 V6 b2 I[add9] b2 I b2.67 I6
+m49 viiø7 b1.33 V6 b2 I b2.67 I6
 m50 IV b1.67 ii6 b2 V b2.67 I6
 m51 ii65 b1.33 V b2 I
 m52 V6 b2 vi

--- a/Corpus/Chamber_Other/Corelli,_Arcangelo/Op3No04/1/analysis.txt
+++ b/Corpus/Chamber_Other/Corelli,_Arcangelo/Op3No04/1/analysis.txt
@@ -25,5 +25,5 @@ m18 iv b1.5 V/iv b2 iv b2.5 V/iv b3 iv b3.5 V/iv b4 iv b4.5 V/iv
 m19 iv b2 iio6 b3 V
 m20 i[add9] b2 i b3 iiø65 b3.5 iiø7 b4 V[no3][add4] b4.5 V
 m21 i b2  b3 iv[add9] b4 iv
-m22 V7 b2 Cad64 b3 V[no3][add4] b3 V b4 V
+m22 V7 b2 Cad64 b3 V
 m23 i

--- a/Corpus/Chamber_Other/Corelli,_Arcangelo/Op4No11/1/analysis.txt
+++ b/Corpus/Chamber_Other/Corelli,_Arcangelo/Op4No11/1/analysis.txt
@@ -7,15 +7,15 @@ Time Signature: 4/4
 m1 c: i b3 V6 b3.5 i b4 V b4.5 i
 m2 V6 b2.5 VI6 b3 V7/III b3.5 IIIM7 b4 VIM7 b4.5 iiø7
 m3 v7 b1.5 i7 b2 iv7 b2.5 V7/III b3 IIIM7 b3.5 VIM7 b4 iiø7 b4.5 V7
-m4 i b1.5 i6 b2 iiø65 b2.5 V b3 i b3.5 v6 b4 IV6[no1][add2] b4 IV6
+m4 i b1.5 i6 b2 iiø65 b2.5 V b3 i b3.5 v6 b4 IV6
 m5 V
 m6 Eb: I b3 V6 b3.5 I b4 V b4.5 I
 m7 V6 b2.5 vi6 b3 viiø7 b3.5 iii7 b4 vi7 b4.5 ii7
 m8 V7 b1.5 IM7 b2 IVM7 b2.5 viiø7 b3 iii7 b3.5 vi7 b4 ii7 b4.5 V7
 m9 I b1.5 I6 b2 IV b3 V7 b3.5 vi b4 ii65 b4.5 V
 m10 I b1.5 c: i6 b2 iiø65 b2.5 V b3 i[add9] b3.5 i b4 iiø2 b4.5 #viio
-m11 g: iv6[no1][add2] iv6 b2 V[no3][add4] b2 V b3 i[add9] b3.5 i b4 iiø2 b4.5 #viio
-m12 i6[no1][add2] i6 b2 IV[add9] b2 IV b3 V7 b3.5 i b4 iiø65 b4.5 V
+m11 g: iv6 b2 V b3 i[add9] b3.5 i b4 iiø2 b4.5 #viio
+m12 i6 b2 IV b3 V7 b3.5 i b4 iiø65 b4.5 V
 m13 i b2.5 f: ii2 b3 V65 b3.5 i b4 iiø65 b4.5 V
 m14 i b2.5 Eb: ii2 b3 V65 b3.5 I b4 ii65 b4.5 V
 m15 I b1.5  b2 c: IVd65 b2.5 #viio b3 i[add9] b3.5 i6 b4 iiø65 b4.5 v


### PR DESCRIPTION
In most of these cases there is at the same position a very complex (computer-generated?) chord like `IV6[no1][add2]` and the same chord simplified `IV6` -- I have opted for the simplified chord.